### PR TITLE
Implement double, split, surrender + OMP parallel simulation

### DIFF
--- a/simulator/include/blackjack/game/game.hpp
+++ b/simulator/include/blackjack/game/game.hpp
@@ -99,7 +99,6 @@ namespace blackjack::game {
             uint8_t hand_index
         ) const noexcept;
 
-        [[nodiscard]] static inline ActionApplicationResult eligibility_result(bool eligible) noexcept;
     };
 }
 
@@ -170,14 +169,52 @@ namespace blackjack::game {
                 state.action_count++;
                 return ActionApplicationResult::APPLIED_TURN_COMPLETE;
 
-            case Decision::DOUBLE:
-                return Game::eligibility_result(this->can_double(player_index, hand_index));
+            case Decision::DOUBLE: {
+                if (!this->can_double(player_index, hand_index)) {
+                    return ActionApplicationResult::ILLEGAL_ACTION;
+                }
+                uint32_t original_bet = player.get_hand(hand_index).get_bet();
+                player.deduct_from_bankroll(original_bet);
+                player.set_hand_bet(hand_index, original_bet * 2);
+                player.add_card_to_hand(hand_index, this->shoe.draw());
+                state.action_count++;
+                return ActionApplicationResult::APPLIED_TURN_COMPLETE;
+            }
 
-            case Decision::SPLIT:
-                return Game::eligibility_result(this->can_split(player_index, hand_index));
+            case Decision::SPLIT: {
+                if (!this->can_split(player_index, hand_index)) {
+                    return ActionApplicationResult::ILLEGAL_ACTION;
+                }
+                uint8_t new_hand_index = player.get_active_hand_count();
+                player.set_active_hand_count(new_hand_index + 1);
 
-            case Decision::SURRENDER:
-                return Game::eligibility_result(this->can_surrender(player_index, hand_index));
+                Card split_card = player.get_hand(hand_index).pop_card();
+                uint32_t split_bet = player.get_hand(hand_index).get_bet();
+
+                player.clear_hand(new_hand_index);
+                player.get_hand(new_hand_index).set_origin(HandOrigin::SPLIT);
+                player.get_hand(new_hand_index).set_bet(split_bet);
+                player.add_card_to_hand(new_hand_index, split_card);
+                player.deduct_from_bankroll(split_bet);
+
+                player.get_hand(hand_index).set_origin(HandOrigin::SPLIT);
+                player.add_card_to_hand(hand_index, this->shoe.draw());
+                player.add_card_to_hand(new_hand_index, this->shoe.draw());
+
+                this->player_hand_states[player_index][new_hand_index].reset();
+                state.action_count++;
+                return ActionApplicationResult::APPLIED_CONTINUE;
+            }
+
+            case Decision::SURRENDER: {
+                if (!this->can_surrender(player_index, hand_index)) {
+                    return ActionApplicationResult::ILLEGAL_ACTION;
+                }
+                player.add_to_bankroll(player.get_hand(hand_index).get_bet() / 2);
+                state.surrendered = true;
+                state.action_count++;
+                return ActionApplicationResult::APPLIED_TURN_COMPLETE;
+            }
         }
 
         std::unreachable();
@@ -415,12 +452,6 @@ namespace blackjack::game {
         };
     }
 
-    [[nodiscard]] inline ActionApplicationResult Game::eligibility_result(bool eligible) noexcept {
-        return eligible
-            ? ActionApplicationResult::UNSUPPORTED_ACTION
-            : ActionApplicationResult::ILLEGAL_ACTION;
-    }
-
     void Game::play_round(uint64_t seed) noexcept {
         this->shoe.shuffle(seed);
 
@@ -453,10 +484,10 @@ namespace blackjack::game {
         }
 
         for (uint8_t i = 0; i < this->player_count; i++) {
-            if (this->players[i].get_active_hand_count() > 0
-                && !this->players[i].get_hand(0).is_blackjack()
-            ) {
-                this->play_turn_for_player(i, 0);
+            for (uint8_t h = 0; h < this->players[i].get_active_hand_count(); h++) {
+                if (!this->players[i].get_hand(h).is_blackjack()) {
+                    this->play_turn_for_player(i, h);
+                }
             }
         }
 

--- a/simulator/include/blackjack/hand/hand.hpp
+++ b/simulator/include/blackjack/hand/hand.hpp
@@ -33,6 +33,7 @@ namespace blackjack::hand {
         inline Hand() noexcept;
 
         inline void add_card(const Card& card) noexcept;
+        [[nodiscard]] inline Card pop_card() noexcept;
         inline void clear() noexcept;
 
         inline void set_bet(uint32_t bet) noexcept;
@@ -80,6 +81,11 @@ namespace blackjack::hand {
         }
 
         return value;
+    }
+
+    [[nodiscard]] inline Card Hand::pop_card() noexcept {
+        assert(this->cards_in_hand > 0);
+        return this->cards[--this->cards_in_hand];
     }
 
     void Hand::clear() noexcept {

--- a/simulator/include/blackjack/player/player.hpp
+++ b/simulator/include/blackjack/player/player.hpp
@@ -53,6 +53,7 @@ namespace blackjack::player {
         inline void add_card_to_hand(uint8_t index, const Card& card) noexcept;
         inline void set_hand_bet(uint8_t index, uint32_t bet) noexcept;
 
+        [[nodiscard]] inline Hand& get_hand(uint8_t index) noexcept;
         [[nodiscard]] inline const Hand& get_hand(uint8_t index) const noexcept;
         [[nodiscard]] inline uint8_t get_active_hand_count() const noexcept;
         inline void set_active_hand_count(uint8_t count) noexcept;
@@ -126,6 +127,10 @@ namespace blackjack::player {
 
     void Player::set_hand_bet(uint8_t index, uint32_t bet) noexcept {
         this->hands[index].set_bet(bet);
+    }
+
+    [[nodiscard]] inline Hand& Player::get_hand(uint8_t index) noexcept {
+        return this->hands[index];
     }
 
     [[nodiscard]] inline const Hand& Player::get_hand(uint8_t index) const noexcept {

--- a/simulator/src/main.cpp
+++ b/simulator/src/main.cpp
@@ -1,26 +1,122 @@
 #include <blackjack/game/game.hpp>
+#include <blackjack/game/betting_config.hpp>
 
+#include <chrono>
+#include <cstdlib>
 #include <iostream>
+#include <omp.h>
+#include <string_view>
+#include <vector>
 
-int main() {
-    constexpr uint64_t SEED = 42;
-    constexpr uint32_t ROUND_COUNT = 100;
+using blackjack::game::BettingConfig;
+using blackjack::game::Game;
+using blackjack::game::GameStatistics;
 
-    blackjack::game::Game game;
-    game.initialize_round();
+struct SimConfig {
+    uint32_t game_count      = 1000;
+    uint32_t rounds_per_game = 100;
+    int      threads         = omp_get_max_threads();
+    BettingConfig betting    = BettingConfig{};
+};
 
-    for (uint32_t i = 0; i < ROUND_COUNT; i++) {
-        game.play_round(SEED + i);
+static void print_usage(const char* prog) {
+    std::cerr << "Usage: " << prog << " [options]\n"
+              << "  --games    N   number of parallel games       (default: 1000)\n"
+              << "  --rounds   N   rounds per game                (default: 100)\n"
+              << "  --threads  N   OMP thread count               (default: max)\n"
+              << "  --min-bet  N   minimum bet in cents           (default: 100)\n"
+              << "  --max-bet  N   maximum bet in cents           (default: 10000)\n"
+              << "  --bankroll N   initial bankroll in cents      (default: 100000)\n";
+}
+
+static SimConfig parse_args(int argc, char* argv[]) {
+    SimConfig cfg;
+    uint32_t min_bet  = BettingConfig::DEFAULT_MIN_BET_CENTS;
+    uint32_t max_bet  = BettingConfig::DEFAULT_MAX_BET_CENTS;
+    uint32_t bankroll = BettingConfig::DEFAULT_INITIAL_BANKROLL_CENTS;
+
+    for (int i = 1; i < argc; i++) {
+        std::string_view arg = argv[i];
+        if ((arg == "--games" || arg == "--rounds" || arg == "--threads" ||
+             arg == "--min-bet" || arg == "--max-bet" || arg == "--bankroll") && i + 1 < argc) {
+            uint32_t val = static_cast<uint32_t>(std::atoi(argv[++i]));
+            if      (arg == "--games")    cfg.game_count      = val;
+            else if (arg == "--rounds")   cfg.rounds_per_game = val;
+            else if (arg == "--threads")  cfg.threads         = static_cast<int>(val);
+            else if (arg == "--min-bet")  min_bet             = val;
+            else if (arg == "--max-bet")  max_bet             = val;
+            else if (arg == "--bankroll") bankroll            = val;
+        } else {
+            std::cerr << "Unknown or incomplete argument: " << arg << "\n";
+            print_usage(argv[0]);
+            std::exit(1);
+        }
     }
 
-    blackjack::game::GameStatistics stats = game.aggregate_statistics();
+    cfg.betting = BettingConfig(min_bet, max_bet, bankroll);
+    return cfg;
+}
 
-    std::cout << "Rounds:           " << ROUND_COUNT << "\n";
-    std::cout << "Hands played:     " << stats.get_hands_played() << "\n";
+static GameStatistics run_simulation(const SimConfig& cfg) {
+    std::vector<Game> games;
+    games.reserve(cfg.game_count);
+    for (uint32_t g = 0; g < cfg.game_count; g++) {
+        games.emplace_back(cfg.betting);
+        games.back().initialize_round();
+    }
+
+    uint64_t total_hands    = 0;
+    uint64_t total_starting = 0;
+    uint64_t total_ending   = 0;
+
+    #pragma omp parallel for num_threads(cfg.threads) reduction(+:total_hands, total_starting, total_ending)
+    for (uint32_t g = 0; g < cfg.game_count; g++) {
+        for (uint32_t r = 0; r < cfg.rounds_per_game; r++) {
+            games[g].play_round(static_cast<uint64_t>(g) * cfg.rounds_per_game + r);
+        }
+        GameStatistics stats = games[g].aggregate_statistics();
+        total_hands    += stats.get_hands_played();
+        total_starting += stats.get_starting_bankroll();
+        total_ending   += stats.get_ending_bankroll();
+    }
+
+    return GameStatistics(
+        total_hands,
+        static_cast<uint32_t>(total_starting),
+        static_cast<uint32_t>(total_ending)
+    );
+}
+
+static void print_results(const SimConfig& cfg, const GameStatistics& stats, double ms) {
+    std::cout << "Threads:           " << cfg.threads << "\n";
+    std::cout << "Games:             " << cfg.game_count << "\n";
+    std::cout << "Rounds per game:   " << cfg.rounds_per_game << "\n";
+    std::cout << "Hands played:      " << stats.get_hands_played() << "\n";
     std::cout << "Starting bankroll: " << stats.get_starting_bankroll() << "\n";
-    std::cout << "Ending bankroll:  " << stats.get_ending_bankroll() << "\n";
-    std::cout << "Bankroll delta:   " << stats.get_bankroll_delta() << "\n";
-    std::cout << "EV per hand:      " << stats.get_expected_value_per_hand() << "\n";
+    std::cout << "Ending bankroll:   " << stats.get_ending_bankroll() << "\n";
+    std::cout << "Bankroll delta:    " << stats.get_bankroll_delta() << "\n";
+    std::cout << "EV per hand:       " << stats.get_expected_value_per_hand() << "\n";
+    std::cout << "Wall time:         " << ms << " ms\n";
+}
+
+int main(int argc, char* argv[]) {
+    SimConfig cfg = parse_args(argc, argv);
+
+    std::cout << "=== Single-threaded ===\n";
+    SimConfig single = cfg;
+    single.threads = 1;
+    auto t0 = std::chrono::steady_clock::now();
+    GameStatistics s1 = run_simulation(single);
+    double t1 = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0).count();
+    print_results(single, s1, t1);
+
+    std::cout << "\n=== Parallel (" << cfg.threads << " threads) ===\n";
+    auto t2 = std::chrono::steady_clock::now();
+    GameStatistics sN = run_simulation(cfg);
+    double tN = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t2).count();
+    print_results(cfg, sN, tN);
+
+    std::cout << "\nSpeedup:           " << (t1 / tN) << "x\n";
 
     return 0;
 }

--- a/simulator/test/test_round.cpp
+++ b/simulator/test/test_round.cpp
@@ -163,7 +163,7 @@ TEST(RoundTest, ApplyDecisionStandEndsTurnExplicitly) {
     EXPECT_EQ(game.apply_decision(0, 0, Decision::HIT), ActionApplicationResult::ILLEGAL_ACTION);
 }
 
-TEST(RoundTest, EligibleDoubleIsExplicitlyUnsupported) {
+TEST(RoundTest, DoubleDrawsOneCardAndDoublesBet) {
     Game game = make_game();
     set_player_hand(
         game,
@@ -173,10 +173,14 @@ TEST(RoundTest, EligibleDoubleIsExplicitlyUnsupported) {
         100
     );
 
-    EXPECT_EQ(game.apply_decision(0, 0, Decision::DOUBLE), ActionApplicationResult::UNSUPPORTED_ACTION);
+    ActionApplicationResult result = game.apply_decision(0, 0, Decision::DOUBLE);
+
+    EXPECT_EQ(result, ActionApplicationResult::APPLIED_TURN_COMPLETE);
+    EXPECT_EQ(game.get_player(0).get_hand(0).card_count(), 3);
+    EXPECT_EQ(game.get_player(0).get_hand(0).get_bet(), 200u);
 }
 
-TEST(RoundTest, EligibleSplitIsExplicitlyUnsupported) {
+TEST(RoundTest, SplitCreatesSecondActiveHand) {
     Game game = make_game();
     set_player_hand(
         game,
@@ -186,10 +190,15 @@ TEST(RoundTest, EligibleSplitIsExplicitlyUnsupported) {
         100
     );
 
-    EXPECT_EQ(game.apply_decision(0, 0, Decision::SPLIT), ActionApplicationResult::UNSUPPORTED_ACTION);
+    ActionApplicationResult result = game.apply_decision(0, 0, Decision::SPLIT);
+
+    EXPECT_EQ(result, ActionApplicationResult::APPLIED_CONTINUE);
+    EXPECT_EQ(game.get_player(0).get_active_hand_count(), 2);
+    EXPECT_EQ(game.get_player(0).get_hand(0).card_count(), 2);
+    EXPECT_EQ(game.get_player(0).get_hand(1).card_count(), 2);
 }
 
-TEST(RoundTest, EligibleSurrenderIsExplicitlyUnsupported) {
+TEST(RoundTest, SurrenderReturnHalfBetAndEndsTurn) {
     Game game = make_game();
     set_player_hand(
         game,
@@ -198,8 +207,12 @@ TEST(RoundTest, EligibleSurrenderIsExplicitlyUnsupported) {
         Card(Suit::HEARTS, Rank::SIX),
         100
     );
+    uint32_t bankroll_before = game.get_player(0).get_bankroll();
 
-    EXPECT_EQ(game.apply_decision(0, 0, Decision::SURRENDER), ActionApplicationResult::UNSUPPORTED_ACTION);
+    ActionApplicationResult result = game.apply_decision(0, 0, Decision::SURRENDER);
+
+    EXPECT_EQ(result, ActionApplicationResult::APPLIED_TURN_COMPLETE);
+    EXPECT_EQ(game.get_player(0).get_bankroll(), bankroll_before + 50);
 }
 
 TEST(RoundTest, ApplyDecisionOnInactiveHandIndexIsIllegal) {


### PR DESCRIPTION
### Notes
  - Hand::pop_card added for split mechanics
  - Non-const Player::get_hand overload — standard dual-overload pattern
  - DOUBLE: deduct bet, draw one card, end turn
  - SPLIT: move second card to new slot, draw for both, continue turn
  - SURRENDER: return half bet, end turn
  - play_round loop now iterates all active hands — catches split hands mid-loop
  - eligibility_result removed — dead after stubs replaced
  - main.cpp rewritten: CLI args, single vs parallel bench, speedup output

### Testing
  - 3 stub tests replaced: verify DOUBLE draws card + doubles bet, SPLIT creates second hand, SURRENDER returns half bet
  - 29/29 passing
  - Release build: 7.1x speedup on 12 threads, identical results single vs parallel