### PR TITLE
fix surrender/double/split settlement and add end-to-end action tests

### DIFF
--- a/simulator/include/blackjack/game/game.hpp
+++ b/simulator/include/blackjack/game/game.hpp
@@ -80,6 +80,7 @@ namespace blackjack::game {
         [[nodiscard]] inline const BettingConfig& get_betting_config() const noexcept;
         [[nodiscard]] inline Player& get_player(uint8_t index) noexcept;
         [[nodiscard]] inline const Player& get_dealer() const noexcept;
+        [[nodiscard]] inline Player& get_dealer() noexcept;
         [[nodiscard]] inline GameStatistics aggregate_statistics() const noexcept;
 
     private:
@@ -177,6 +178,7 @@ namespace blackjack::game {
                 player.deduct_from_bankroll(original_bet);
                 player.set_hand_bet(hand_index, original_bet * 2);
                 player.add_card_to_hand(hand_index, this->shoe.draw());
+                state.doubled = true;
                 state.action_count++;
                 return ActionApplicationResult::APPLIED_TURN_COMPLETE;
             }
@@ -211,6 +213,7 @@ namespace blackjack::game {
                     return ActionApplicationResult::ILLEGAL_ACTION;
                 }
                 player.add_to_bankroll(player.get_hand(hand_index).get_bet() / 2);
+                player.get_hand(hand_index).set_surrendered(true);
                 state.surrendered = true;
                 state.action_count++;
                 return ActionApplicationResult::APPLIED_TURN_COMPLETE;
@@ -225,6 +228,10 @@ namespace blackjack::game {
         const Hand& dealer_hand
     ) const noexcept {
         bool was_split = (player_hand.get_origin() == HandOrigin::SPLIT);
+
+        if (player_hand.is_surrendered()) {
+            return HandOutcome::SURRENDER_LOSS;
+        }
 
         if (player_hand.is_bust()) {
             return HandOutcome::PLAYER_BUST_LOSS;
@@ -281,6 +288,7 @@ namespace blackjack::game {
             case HandOutcome::PLAYER_BUST_LOSS:
             case HandOutcome::DEALER_WIN_LOSS:
             case HandOutcome::DEALER_BLACKJACK_LOSS:
+            case HandOutcome::SURRENDER_LOSS:
                 return 0;
         }
     }
@@ -303,6 +311,10 @@ namespace blackjack::game {
     }
 
     [[nodiscard]] inline const Player& Game::get_dealer() const noexcept {
+        return this->dealer;
+    }
+
+    [[nodiscard]] inline Player& Game::get_dealer() noexcept {
         return this->dealer;
     }
 
@@ -431,7 +443,8 @@ namespace blackjack::game {
         return hand.is_bust()
             || hand.is_blackjack()
             || state.stood
-            || state.surrendered;
+            || state.surrendered
+            || state.doubled;
     }
 
     [[nodiscard]] inline bool Game::is_dealer_turn_complete() const noexcept {

--- a/simulator/include/blackjack/game/hand_round_state.hpp
+++ b/simulator/include/blackjack/game/hand_round_state.hpp
@@ -12,17 +12,20 @@ namespace blackjack::game {
         uint8_t action_count;
         bool stood;
         bool surrendered;
+        bool doubled;
 
         HandRoundState() noexcept
             : action_count(0)
             , stood(false)
             , surrendered(false)
+            , doubled(false)
         {}
 
         void reset() noexcept {
             this->action_count = 0;
             this->stood = false;
             this->surrendered = false;
+            this->doubled = false;
         }
     };
 }

--- a/simulator/include/blackjack/hand/hand.hpp
+++ b/simulator/include/blackjack/hand/hand.hpp
@@ -28,6 +28,7 @@ namespace blackjack::hand {
         uint8_t cards_in_hand;
         uint32_t bet_cents;
         HandOrigin origin;
+        bool surrendered;
 
     public:
         inline Hand() noexcept;
@@ -41,6 +42,9 @@ namespace blackjack::hand {
 
         inline void set_origin(HandOrigin new_origin) noexcept;
         [[nodiscard]] inline HandOrigin get_origin() const noexcept;
+
+        inline void set_surrendered(bool value) noexcept;
+        [[nodiscard]] inline bool is_surrendered() const noexcept;
 
         [[nodiscard]] inline uint8_t get_value() const noexcept;
         [[nodiscard]] inline bool is_blackjack() const noexcept;
@@ -57,6 +61,7 @@ namespace blackjack::hand {
         , cards_in_hand(0)
         , bet_cents(0)
         , origin(HandOrigin::NATURAL)
+        , surrendered(false)
     {}
 
     void Hand::add_card(const Card& card) noexcept {
@@ -92,6 +97,7 @@ namespace blackjack::hand {
         this->cards_in_hand = 0;
         this->bet_cents = 0;
         this->origin = HandOrigin::NATURAL;
+        this->surrendered = false;
     }
 
     void Hand::set_bet(uint32_t bet) noexcept {
@@ -108,6 +114,14 @@ namespace blackjack::hand {
 
     [[nodiscard]] inline HandOrigin Hand::get_origin() const noexcept {
         return this->origin;
+    }
+
+    void Hand::set_surrendered(bool value) noexcept {
+        this->surrendered = value;
+    }
+
+    [[nodiscard]] inline bool Hand::is_surrendered() const noexcept {
+        return this->surrendered;
     }
 
     [[nodiscard]] inline bool Hand::is_blackjack() const noexcept {

--- a/simulator/include/blackjack/hand/hand_outcome.hpp
+++ b/simulator/include/blackjack/hand/hand_outcome.hpp
@@ -12,6 +12,7 @@ namespace blackjack::hand {
         PLAYER_BUST_LOSS,
         DEALER_WIN_LOSS,
         DEALER_BLACKJACK_LOSS,
+        SURRENDER_LOSS,
 
         PUSH,
     };

--- a/simulator/test/test_round.cpp
+++ b/simulator/test/test_round.cpp
@@ -1,5 +1,7 @@
 #include <blackjack/game/game.hpp>
 #include <blackjack/game/betting_config.hpp>
+#include <blackjack/hand/hand_origin.hpp>
+#include <blackjack/hand/hand_outcome.hpp>
 #include <blackjack/player/strategy/bearish.hpp>
 #include <blackjack/player/strategy/bullish.hpp>
 #include <blackjack/player/strategy/strategy.hpp>
@@ -16,8 +18,9 @@ using blackjack::game::ActionApplicationResult;
 using blackjack::game::BettingConfig;
 using blackjack::game::Game;
 using blackjack::hand::Hand;
+using blackjack::hand::HandOrigin;
+using blackjack::hand::HandOutcome;
 using blackjack::player::strategy::BearishStrategy;
-using blackjack::player::strategy::BullishStrategy;
 using blackjack::player::strategy::Decision;
 
 static Game make_game() {
@@ -112,7 +115,6 @@ TEST(RoundTest, SameSeedProducesDeterministicBankrollDelta) {
 }
 
 TEST(RoundTest, DifferentSeedsMayProduceDifferentOutcomes) {
-    // Run many seeds; at least one pair should differ (collision would be astronomically unlikely)
     bool found_difference = false;
 
     Game base = make_game();
@@ -225,14 +227,12 @@ TEST(RoundTest, ApplyDecisionOnInactiveHandIndexIsIllegal) {
         100
     );
 
-    // active_hand_count is 1, so hand_index 1..MAX-1 are all inactive.
     EXPECT_EQ(game.apply_decision(0, 1, Decision::HIT), ActionApplicationResult::ILLEGAL_ACTION);
     EXPECT_EQ(game.apply_decision(0, 1, Decision::STAND), ActionApplicationResult::ILLEGAL_ACTION);
 }
 
 TEST(RoundTest, HitUntilBustCompletesTurnAndRejectsFurtherActions) {
     Game game = make_game();
-    // Force a guaranteed-bust scenario: 10 + 6 + extra hits until value > 21.
     set_player_hand(
         game,
         0,
@@ -246,11 +246,384 @@ TEST(RoundTest, HitUntilBustCompletesTurnAndRejectsFurtherActions) {
         result = game.apply_decision(0, 0, Decision::HIT);
     }
 
-    // Whichever card busts the hand, the final HIT must report turn-complete.
     EXPECT_EQ(result, ActionApplicationResult::APPLIED_TURN_COMPLETE);
     EXPECT_TRUE(game.get_player(0).get_hand(0).is_bust());
 
-    // Subsequent actions on a completed hand are illegal.
     EXPECT_EQ(game.apply_decision(0, 0, Decision::HIT), ActionApplicationResult::ILLEGAL_ACTION);
     EXPECT_EQ(game.apply_decision(0, 0, Decision::STAND), ActionApplicationResult::ILLEGAL_ACTION);
+}
+
+static void set_dealer_hand(Game& game, Card first, Card second) {
+    auto& dealer = game.get_dealer();
+    dealer.clear_hand(0);
+    dealer.add_card_to_hand(0, first);
+    dealer.add_card_to_hand(0, second);
+}
+
+static void setup_hand_with_placed_bet(
+    Game& game,
+    uint8_t player_index,
+    Card first,
+    Card second,
+    uint32_t bet
+) {
+    auto& player = game.get_player(player_index);
+    player.clear_hand(0);
+    player.set_active_hand_count(1);
+    player.add_card_to_hand(0, first);
+    player.add_card_to_hand(0, second);
+    player.set_hand_bet(0, bet);
+    player.deduct_from_bankroll(bet);
+}
+
+static void replace_last_card(Hand& hand, Card replacement) {
+    (void) hand.pop_card();
+    hand.add_card(replacement);
+}
+
+TEST(ActionLifecycleTest, DoubleBlocksAllSubsequentActions) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::FIVE),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::DOUBLE), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::HIT),       ActionApplicationResult::ILLEGAL_ACTION);
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::STAND),     ActionApplicationResult::ILLEGAL_ACTION);
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::DOUBLE),    ActionApplicationResult::ILLEGAL_ACTION);
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::SPLIT),     ActionApplicationResult::ILLEGAL_ACTION);
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::SURRENDER), ActionApplicationResult::ILLEGAL_ACTION);
+}
+
+TEST(ActionLifecycleTest, DoubleWinPaysTwoToOneOnDoubledStake) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::FIVE),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::DOUBLE), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+    replace_last_card(game.get_player(0).get_hand(0), Card(Suit::CLUBS, Rank::NINE));
+    ASSERT_EQ(game.get_player(0).get_hand(0).get_value(), 20u);
+    ASSERT_EQ(game.get_player(0).get_hand(0).get_bet(), 200u);
+
+    set_dealer_hand(game, Card(Suit::DIAMONDS, Rank::NINE), Card(Suit::HEARTS, Rank::NINE));
+
+    game.resolve_hand(game.get_player(0), 0);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll + 200);
+}
+
+TEST(ActionLifecycleTest, DoubleLossLosesDoubledStake) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::FIVE),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::DOUBLE), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+    replace_last_card(game.get_player(0).get_hand(0), Card(Suit::CLUBS, Rank::FOUR));
+    ASSERT_EQ(game.get_player(0).get_hand(0).get_value(), 15u);
+
+    set_dealer_hand(game, Card(Suit::DIAMONDS, Rank::NINE), Card(Suit::HEARTS, Rank::NINE));
+
+    game.resolve_hand(game.get_player(0), 0);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll - 200);
+}
+
+TEST(ActionLifecycleTest, DoubleBustLosesDoubledStake) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::TEN),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::DOUBLE), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+    replace_last_card(game.get_player(0).get_hand(0), Card(Suit::CLUBS, Rank::KING));
+    ASSERT_TRUE(game.get_player(0).get_hand(0).is_bust());
+
+    set_dealer_hand(game, Card(Suit::DIAMONDS, Rank::NINE), Card(Suit::HEARTS, Rank::EIGHT));
+
+    game.resolve_hand(game.get_player(0), 0);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll - 200);
+}
+
+TEST(ActionLifecycleTest, DoublePushReturnsDoubledStake) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::FIVE),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::DOUBLE), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+    replace_last_card(game.get_player(0).get_hand(0), Card(Suit::CLUBS, Rank::SEVEN));
+    ASSERT_EQ(game.get_player(0).get_hand(0).get_value(), 18u);
+
+    set_dealer_hand(game, Card(Suit::DIAMONDS, Rank::NINE), Card(Suit::HEARTS, Rank::NINE));
+
+    game.resolve_hand(game.get_player(0), 0);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll);
+}
+
+TEST(ActionLifecycleTest, SurrenderBlocksAllSubsequentActions) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::TEN),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SURRENDER), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::HIT),       ActionApplicationResult::ILLEGAL_ACTION);
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::STAND),     ActionApplicationResult::ILLEGAL_ACTION);
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::DOUBLE),    ActionApplicationResult::ILLEGAL_ACTION);
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::SPLIT),     ActionApplicationResult::ILLEGAL_ACTION);
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::SURRENDER), ActionApplicationResult::ILLEGAL_ACTION);
+}
+
+TEST(ActionLifecycleTest, SurrenderOutcomeReportsSurrenderLossWithZeroPayout) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::TEN),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SURRENDER), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+
+    const Hand& player_hand = game.get_player(0).get_hand(0);
+    Hand dealer_hand;
+    dealer_hand.add_card(Card(Suit::DIAMONDS, Rank::NINE));
+    dealer_hand.add_card(Card(Suit::CLUBS, Rank::NINE));
+
+    EXPECT_EQ(game.determine_outcome(player_hand, dealer_hand), HandOutcome::SURRENDER_LOSS);
+    EXPECT_EQ(game.calculate_payout(HandOutcome::SURRENDER_LOSS, 100), 0u);
+}
+
+TEST(ActionLifecycleTest, SurrenderSettlementSkipsRegularPayoutOnDealerBust) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::TEN),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SURRENDER), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+
+    set_dealer_hand(game, Card(Suit::DIAMONDS, Rank::KING), Card(Suit::CLUBS, Rank::KING));
+    game.get_dealer().add_card_to_hand(0, Card(Suit::HEARTS, Rank::FIVE));
+    ASSERT_TRUE(game.get_dealer().get_hand(0).is_bust());
+
+    game.resolve_hand(game.get_player(0), 0);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll - 50);
+    EXPECT_EQ(game.aggregate_statistics().get_hands_played(), 1u);
+}
+
+TEST(ActionLifecycleTest, SurrenderSettlementSkipsRegularPayoutOnDealerPush) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::TEN),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SURRENDER), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+
+    set_dealer_hand(game, Card(Suit::DIAMONDS, Rank::NINE), Card(Suit::CLUBS, Rank::SEVEN));
+
+    game.resolve_hand(game.get_player(0), 0);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll - 50);
+}
+
+TEST(ActionLifecycleTest, SurrenderSettlementSkipsRegularPayoutOnPlayerHigherValue) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::TEN),
+        Card(Suit::HEARTS, Rank::TEN), 
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SURRENDER), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+
+    set_dealer_hand(game, Card(Suit::DIAMONDS, Rank::NINE), Card(Suit::CLUBS, Rank::NINE));
+
+    game.resolve_hand(game.get_player(0), 0);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll - 50);
+}
+
+TEST(ActionLifecycleTest, SurrenderAgainstDealerBlackjackStillOnlyLosesHalf) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::TEN),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SURRENDER), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+
+    set_dealer_hand(game, Card(Suit::DIAMONDS, Rank::ACE), Card(Suit::CLUBS, Rank::KING));
+    ASSERT_TRUE(game.get_dealer().get_hand(0).is_blackjack());
+
+    game.resolve_hand(game.get_player(0), 0);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll - 50);
+}
+
+TEST(ActionLifecycleTest, SplitDeductsSecondBetAndMarksBothHandsSplitOrigin) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::EIGHT),
+        Card(Suit::HEARTS, Rank::EIGHT),
+        100
+    );
+    uint32_t bankroll_before_split = game.get_player(0).get_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SPLIT), ActionApplicationResult::APPLIED_CONTINUE);
+
+    auto& player = game.get_player(0);
+    EXPECT_EQ(player.get_bankroll(), bankroll_before_split - 100);
+    EXPECT_EQ(player.get_active_hand_count(), 2);
+    EXPECT_EQ(player.get_hand(0).get_bet(), 100u);
+    EXPECT_EQ(player.get_hand(1).get_bet(), 100u);
+    EXPECT_EQ(player.get_hand(0).get_origin(), HandOrigin::SPLIT);
+    EXPECT_EQ(player.get_hand(1).get_origin(), HandOrigin::SPLIT);
+}
+
+TEST(ActionLifecycleTest, SplitBothHandsWinSettledIndependently) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::EIGHT),
+        Card(Suit::HEARTS, Rank::EIGHT),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SPLIT), ActionApplicationResult::APPLIED_CONTINUE);
+
+    replace_last_card(game.get_player(0).get_hand(0), Card(Suit::CLUBS, Rank::TEN));
+    replace_last_card(game.get_player(0).get_hand(1), Card(Suit::DIAMONDS, Rank::TEN));
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::STAND), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+    ASSERT_EQ(game.apply_decision(0, 1, Decision::STAND), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+
+    set_dealer_hand(game, Card(Suit::HEARTS, Rank::TEN), Card(Suit::SPADES, Rank::SEVEN));
+
+    game.resolve_hand(game.get_player(0), 0);
+    game.resolve_hand(game.get_player(0), 1);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll + 200);
+    EXPECT_EQ(game.aggregate_statistics().get_hands_played(), 2u);
+}
+
+TEST(ActionLifecycleTest, SplitOneWinOneLossSettlesEachHandSeparately) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::EIGHT),
+        Card(Suit::HEARTS, Rank::EIGHT),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SPLIT), ActionApplicationResult::APPLIED_CONTINUE);
+
+    replace_last_card(game.get_player(0).get_hand(0), Card(Suit::CLUBS, Rank::TEN));
+    replace_last_card(game.get_player(0).get_hand(1), Card(Suit::DIAMONDS, Rank::FIVE));
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::STAND), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+    ASSERT_EQ(game.apply_decision(0, 1, Decision::STAND), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+
+    set_dealer_hand(game, Card(Suit::HEARTS, Rank::TEN), Card(Suit::SPADES, Rank::SEVEN));
+
+    game.resolve_hand(game.get_player(0), 0);
+    game.resolve_hand(game.get_player(0), 1);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll);
+    EXPECT_EQ(game.aggregate_statistics().get_hands_played(), 2u);
+}
+
+TEST(ActionLifecycleTest, SplitTwentyOneDoesNotPayBlackjackOdds) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::ACE),
+        Card(Suit::HEARTS, Rank::ACE),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SPLIT), ActionApplicationResult::APPLIED_CONTINUE);
+    replace_last_card(game.get_player(0).get_hand(0), Card(Suit::CLUBS, Rank::KING));
+    replace_last_card(game.get_player(0).get_hand(1), Card(Suit::DIAMONDS, Rank::QUEEN));
+
+    ASSERT_EQ(game.get_player(0).get_hand(0).get_value(), 21u);
+    ASSERT_EQ(game.get_player(0).get_hand(1).get_value(), 21u);
+
+    set_dealer_hand(game, Card(Suit::HEARTS, Rank::TEN), Card(Suit::SPADES, Rank::SEVEN));
+
+    game.resolve_hand(game.get_player(0), 0);
+    game.resolve_hand(game.get_player(0), 1);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll + 200);
+}
+
+TEST(ActionLifecycleTest, SplitHandBustOnlyLosesThatHandsStake) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::EIGHT),
+        Card(Suit::HEARTS, Rank::EIGHT),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SPLIT), ActionApplicationResult::APPLIED_CONTINUE);
+
+    replace_last_card(game.get_player(0).get_hand(0), Card(Suit::CLUBS, Rank::TEN));
+    replace_last_card(game.get_player(0).get_hand(1), Card(Suit::DIAMONDS, Rank::FIVE));
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::STAND), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+    game.get_player(0).get_hand(1).add_card(Card(Suit::CLUBS, Rank::KING));
+    ASSERT_TRUE(game.get_player(0).get_hand(1).is_bust());
+
+    set_dealer_hand(game, Card(Suit::HEARTS, Rank::TEN), Card(Suit::SPADES, Rank::SEVEN));
+
+    game.resolve_hand(game.get_player(0), 0);
+    game.resolve_hand(game.get_player(0), 1);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll);
 }


### PR DESCRIPTION
## Notes

- Correct the remaining business logic holes in the action engine, mainly surrendered hand resolution and full-round settlement for doubled/split hands

## Testing

- `./make.sh test`

```
Filename                         Regions    Missed Regions     Cover   Functions  Missed Functions  Executed       Lines      Missed Lines     Cover    Branches   Missed Branches     Cover
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
card/card.hpp                         12                 1    91.67%           5                 1    80.00%          22                 3    86.36%          10                 0   100.00%
deck/deck.hpp                         16                 6    62.50%           5                 1    80.00%          26                11    57.69%           2                 1    50.00%
deck/shoe.hpp                         12                 2    83.33%           4                 1    75.00%          20                 6    70.00%           4                 1    75.00%
game/betting_config.hpp               21                 3    85.71%           9                 3    66.67%          33                 9    72.73%           4                 2    50.00%
game/game.hpp                        186                11    94.09%          25                 1    96.00%         315                20    93.65%         156                25    83.97%
game/game_statistics.hpp              12                 1    91.67%           6                 0   100.00%          24                 2    91.67%           2                 1    50.00%
game/hand_round_state.hpp              6                 0   100.00%           2                 0   100.00%          11                 0   100.00%           0                 0         -
hand/hand.hpp                         49                10    79.59%          15                 0   100.00%          65                 0   100.00%          16                 2    87.50%
player/player.hpp                     27                 2    92.59%          16                 0   100.00%          59                 4    93.22%           4                 2    50.00%
player/strategy/bearish.hpp            4                 1    75.00%           1                 0   100.00%           5                 0   100.00%           2                 1    50.00%
player/strategy/bullish.hpp            1                 1     0.00%           1                 1     0.00%           5                 5     0.00%           0                 0         -
player/strategy/dealer.hpp             4                 0   100.00%           1                 0   100.00%           5                 0   100.00%           2                 0   100.00%
player/strategy/strategy.hpp          12                 5    58.33%           9                 5    44.44%          26                15    42.31%           0                 0         -
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                362                43    88.12%          99                13    86.87%         616                75    87.82%         202                35    82.67%
```