### PR TITLE
Ruleset

### DIFF
--- a/simulator/include/blackjack/game/betting_config.hpp
+++ b/simulator/include/blackjack/game/betting_config.hpp
@@ -9,32 +9,23 @@ namespace blackjack::game {
         uint32_t min_bet_cents;
         uint32_t max_bet_cents;
         uint32_t initial_bankroll_cents;
-        uint8_t blackjack_payout_numerator;
-        uint8_t blackjack_payout_denominator;
 
     public:
         static constexpr uint32_t DEFAULT_MIN_BET_CENTS = 100;
         static constexpr uint32_t DEFAULT_MAX_BET_CENTS = 10000;
         static constexpr uint32_t DEFAULT_INITIAL_BANKROLL_CENTS = 100000;
-        static constexpr uint8_t DEFAULT_BLACKJACK_PAYOUT_NUMERATOR = 3;
-        static constexpr uint8_t DEFAULT_BLACKJACK_PAYOUT_DENOMINATOR = 2;
 
         inline BettingConfig() noexcept;
         explicit inline BettingConfig(
             uint32_t min_bet,
             uint32_t max_bet,
-            uint32_t initial_bankroll,
-            uint8_t bj_payout_num = DEFAULT_BLACKJACK_PAYOUT_NUMERATOR,
-            uint8_t bj_payout_denom = DEFAULT_BLACKJACK_PAYOUT_DENOMINATOR
+            uint32_t initial_bankroll
         ) noexcept;
 
         [[nodiscard]] uint32_t get_min_bet() const noexcept;
         [[nodiscard]] uint32_t get_max_bet() const noexcept;
         [[nodiscard]] uint32_t get_initial_bankroll() const noexcept;
-        [[nodiscard]] uint8_t get_blackjack_payout_numerator() const noexcept;
-        [[nodiscard]] uint8_t get_blackjack_payout_denominator() const noexcept;
         [[nodiscard]] bool is_valid_bet(uint32_t bet) const noexcept;
-        [[nodiscard]] uint32_t calculate_blackjack_payout(uint32_t bet) const noexcept;
     };
 }
 
@@ -44,22 +35,16 @@ namespace blackjack::game {
         : min_bet_cents(DEFAULT_MIN_BET_CENTS)
         , max_bet_cents(DEFAULT_MAX_BET_CENTS)
         , initial_bankroll_cents(DEFAULT_INITIAL_BANKROLL_CENTS)
-        , blackjack_payout_numerator(DEFAULT_BLACKJACK_PAYOUT_NUMERATOR)
-        , blackjack_payout_denominator(DEFAULT_BLACKJACK_PAYOUT_DENOMINATOR)
     {}
 
     BettingConfig::BettingConfig(
         uint32_t min_bet,
         uint32_t max_bet,
-        uint32_t initial_bankroll,
-        uint8_t bj_payout_num,
-        uint8_t bj_payout_denom
+        uint32_t initial_bankroll
     ) noexcept
         : min_bet_cents(min_bet)
         , max_bet_cents(max_bet)
         , initial_bankroll_cents(initial_bankroll)
-        , blackjack_payout_numerator(bj_payout_num)
-        , blackjack_payout_denominator(bj_payout_denom)
     {}
 
     [[nodiscard]] inline uint32_t BettingConfig::get_min_bet() const noexcept {
@@ -74,20 +59,8 @@ namespace blackjack::game {
         return this->initial_bankroll_cents;
     }
 
-    [[nodiscard]] inline uint8_t BettingConfig::get_blackjack_payout_numerator() const noexcept {
-        return this->blackjack_payout_numerator;
-    }
-
-    [[nodiscard]] inline uint8_t BettingConfig::get_blackjack_payout_denominator() const noexcept {
-        return this->blackjack_payout_denominator;
-    }
-
     [[nodiscard]] inline bool BettingConfig::is_valid_bet(uint32_t bet) const noexcept {
         return bet >= this->min_bet_cents && bet <= this->max_bet_cents;
-    }
-
-    [[nodiscard]] inline uint32_t BettingConfig::calculate_blackjack_payout(uint32_t bet) const noexcept {
-        return bet + (bet * this->blackjack_payout_numerator / this->blackjack_payout_denominator);
     }
 }
 

--- a/simulator/include/blackjack/game/game.hpp
+++ b/simulator/include/blackjack/game/game.hpp
@@ -80,6 +80,7 @@ namespace blackjack::game {
         [[nodiscard]] inline const BettingConfig& get_betting_config() const noexcept;
         [[nodiscard]] inline Player& get_player(uint8_t index) noexcept;
         [[nodiscard]] inline const Player& get_dealer() const noexcept;
+        [[nodiscard]] inline Player& get_dealer() noexcept;
         [[nodiscard]] inline GameStatistics aggregate_statistics() const noexcept;
 
     private:
@@ -177,6 +178,7 @@ namespace blackjack::game {
                 player.deduct_from_bankroll(original_bet);
                 player.set_hand_bet(hand_index, original_bet * 2);
                 player.add_card_to_hand(hand_index, this->shoe.draw());
+                state.doubled = true;
                 state.action_count++;
                 return ActionApplicationResult::APPLIED_TURN_COMPLETE;
             }
@@ -211,6 +213,7 @@ namespace blackjack::game {
                     return ActionApplicationResult::ILLEGAL_ACTION;
                 }
                 player.add_to_bankroll(player.get_hand(hand_index).get_bet() / 2);
+                player.get_hand(hand_index).set_surrendered(true);
                 state.surrendered = true;
                 state.action_count++;
                 return ActionApplicationResult::APPLIED_TURN_COMPLETE;
@@ -225,6 +228,10 @@ namespace blackjack::game {
         const Hand& dealer_hand
     ) const noexcept {
         bool was_split = (player_hand.get_origin() == HandOrigin::SPLIT);
+
+        if (player_hand.is_surrendered()) {
+            return HandOutcome::SURRENDER_LOSS;
+        }
 
         if (player_hand.is_bust()) {
             return HandOutcome::PLAYER_BUST_LOSS;
@@ -281,6 +288,7 @@ namespace blackjack::game {
             case HandOutcome::PLAYER_BUST_LOSS:
             case HandOutcome::DEALER_WIN_LOSS:
             case HandOutcome::DEALER_BLACKJACK_LOSS:
+            case HandOutcome::SURRENDER_LOSS:
                 return 0;
         }
     }
@@ -303,6 +311,10 @@ namespace blackjack::game {
     }
 
     [[nodiscard]] inline const Player& Game::get_dealer() const noexcept {
+        return this->dealer;
+    }
+
+    [[nodiscard]] inline Player& Game::get_dealer() noexcept {
         return this->dealer;
     }
 
@@ -431,7 +443,8 @@ namespace blackjack::game {
         return hand.is_bust()
             || hand.is_blackjack()
             || state.stood
-            || state.surrendered;
+            || state.surrendered
+            || state.doubled;
     }
 
     [[nodiscard]] inline bool Game::is_dealer_turn_complete() const noexcept {

--- a/simulator/include/blackjack/game/game.hpp
+++ b/simulator/include/blackjack/game/game.hpp
@@ -6,10 +6,12 @@
 #include <blackjack/game/betting_config.hpp>
 #include <blackjack/game/game_statistics.hpp>
 #include <blackjack/game/hand_round_state.hpp>
+#include <blackjack/game/ruleset.hpp>
 #include <blackjack/hand/hand_origin.hpp>
 #include <blackjack/hand/hand_outcome.hpp>
 #include <blackjack/player/strategy/dealer.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <utility>
@@ -48,12 +50,15 @@ namespace blackjack::game {
         HandRoundState dealer_hand_state;
         uint8_t player_count;
         BettingConfig betting_config;
+        Ruleset ruleset;
+        DealerStrategy dealer_strategy;
         uint64_t hands_played_count;
         uint32_t starting_bankroll_total;
 
     public:
         inline Game() noexcept;
         explicit inline Game(const BettingConfig& config) noexcept;
+        inline Game(const BettingConfig& config, const Ruleset& rules) noexcept;
 
         inline void initialize_round() noexcept;
         inline void play_round(uint64_t seed) noexcept;
@@ -78,10 +83,16 @@ namespace blackjack::game {
         ) const noexcept;
 
         [[nodiscard]] inline const BettingConfig& get_betting_config() const noexcept;
+        [[nodiscard]] inline const Ruleset& get_ruleset() const noexcept;
         [[nodiscard]] inline Player& get_player(uint8_t index) noexcept;
         [[nodiscard]] inline const Player& get_dealer() const noexcept;
         [[nodiscard]] inline Player& get_dealer() noexcept;
         [[nodiscard]] inline GameStatistics aggregate_statistics() const noexcept;
+
+        [[nodiscard]] inline LegalActions get_legal_actions(
+            uint8_t player_index,
+            uint8_t hand_index
+        ) const noexcept;
 
     private:
         [[nodiscard]] inline ActionApplicationResult apply_dealer_decision(Decision decision) noexcept;
@@ -95,11 +106,7 @@ namespace blackjack::game {
         [[nodiscard]] inline bool can_surrender(uint8_t player_index, uint8_t hand_index) const noexcept;
         [[nodiscard]] inline bool is_hand_turn_complete(uint8_t player_index, uint8_t hand_index) const noexcept;
         [[nodiscard]] inline bool is_dealer_turn_complete() const noexcept;
-        [[nodiscard]] inline LegalActions make_legal_actions(
-            uint8_t player_index,
-            uint8_t hand_index
-        ) const noexcept;
-
+        [[nodiscard]] inline uint8_t effective_max_split_hands() const noexcept;
     };
 }
 
@@ -113,6 +120,8 @@ namespace blackjack::game {
         , dealer_hand_state()
         , player_count(MAX_NON_DEALER_PLAYERS)
         , betting_config()
+        , ruleset(Ruleset::default_vegas())
+        , dealer_strategy(ruleset.dealer_hits_soft_17)
         , hands_played_count(0)
         , starting_bankroll_total(0)
     {}
@@ -125,6 +134,22 @@ namespace blackjack::game {
         , dealer_hand_state()
         , player_count(MAX_NON_DEALER_PLAYERS)
         , betting_config(config)
+        , ruleset(Ruleset::default_vegas())
+        , dealer_strategy(ruleset.dealer_hits_soft_17)
+        , hands_played_count(0)
+        , starting_bankroll_total(0)
+    {}
+
+    Game::Game(const BettingConfig& config, const Ruleset& rules) noexcept
+        : players({})
+        , player_hand_states({})
+        , shoe()
+        , dealer()
+        , dealer_hand_state()
+        , player_count(MAX_NON_DEALER_PLAYERS)
+        , betting_config(config)
+        , ruleset(rules)
+        , dealer_strategy(rules.dealer_hits_soft_17)
         , hands_played_count(0)
         , starting_bankroll_total(0)
     {}
@@ -276,7 +301,7 @@ namespace blackjack::game {
     [[nodiscard]] inline uint32_t Game::calculate_payout(HandOutcome outcome, uint32_t bet) const noexcept {
         switch (outcome) {
             case HandOutcome::BLACKJACK_WIN:
-                return this->betting_config.calculate_blackjack_payout(bet);
+                return this->ruleset.calculate_blackjack_payout(bet);
 
             case HandOutcome::REGULAR_WIN:
             case HandOutcome::DEALER_BUST_WIN:
@@ -306,6 +331,10 @@ namespace blackjack::game {
         return this->betting_config;
     }
 
+    [[nodiscard]] inline const Ruleset& Game::get_ruleset() const noexcept {
+        return this->ruleset;
+    }
+
     [[nodiscard]] inline Player& Game::get_player(uint8_t index) noexcept {
         return this->players[index];
     }
@@ -328,6 +357,17 @@ namespace blackjack::game {
             this->starting_bankroll_total,
             static_cast<uint32_t>(total_ending)
         );
+    }
+
+    [[nodiscard]] inline LegalActions Game::get_legal_actions(
+        uint8_t player_index,
+        uint8_t hand_index
+    ) const noexcept {
+        return LegalActions{
+            this->can_double(player_index, hand_index),
+            this->can_split(player_index, hand_index),
+            this->can_surrender(player_index, hand_index),
+        };
     }
 
     inline ActionApplicationResult Game::apply_dealer_decision(Decision decision) noexcept {
@@ -354,18 +394,16 @@ namespace blackjack::game {
     }
 
     void Game::play_turn_for_player(uint8_t player_index, uint8_t hand_index) noexcept {
-        static DealerStrategy fallback;
-
         Player& player = this->players[player_index];
         PlayerStrategy* strategy = player.get_strategy();
-        PlayerStrategy* effective = strategy ? strategy : &fallback;
+        PlayerStrategy* effective = strategy ? strategy : &this->dealer_strategy;
 
         while (!this->is_hand_turn_complete(player_index, hand_index)) {
             const Card& upcard = this->dealer.get_hand(0).get_cards_data()[1];
             GameContext ctx(
                 player.get_hand(hand_index),
                 upcard,
-                this->make_legal_actions(player_index, hand_index)
+                this->get_legal_actions(player_index, hand_index)
             );
             ActionApplicationResult result = this->apply_decision(
                 player_index,
@@ -380,12 +418,13 @@ namespace blackjack::game {
     }
 
     void Game::play_dealer_turn() noexcept {
-        DealerStrategy dealer_strategy;
         const Card& upcard = this->dealer.get_hand(0).get_cards_data()[1];
 
         while (!this->is_dealer_turn_complete()) {
             GameContext ctx(this->dealer.get_hand(0), upcard, LegalActions::none());
-            ActionApplicationResult result = this->apply_dealer_decision(dealer_strategy.get_decision(ctx));
+            ActionApplicationResult result = this->apply_dealer_decision(
+                this->dealer_strategy.get_decision(ctx)
+            );
             if (result == ActionApplicationResult::APPLIED_TURN_COMPLETE) {
                 break;
             }
@@ -404,9 +443,21 @@ namespace blackjack::game {
         return this->get_player_hand_state(player_index, hand_index).action_count == 0;
     }
 
+    [[nodiscard]] inline uint8_t Game::effective_max_split_hands() const noexcept {
+        return std::min(
+            this->ruleset.max_split_hands,
+            Player::MAX_POSSIBLE_HANDS
+        );
+    }
+
     [[nodiscard]] inline bool Game::can_double(uint8_t player_index, uint8_t hand_index) const noexcept {
         const Player& player = this->players[player_index];
         const Hand& hand = player.get_hand(hand_index);
+
+        bool is_split_hand = (hand.get_origin() == HandOrigin::SPLIT);
+        if (is_split_hand && !this->ruleset.double_after_split_allowed) {
+            return false;
+        }
 
         return this->is_first_action(player_index, hand_index)
             && hand.card_count() == 2
@@ -423,17 +474,22 @@ namespace blackjack::game {
 
         const Card* cards = hand.get_cards_data();
 
-        return player.get_active_hand_count() < Player::MAX_POSSIBLE_HANDS
+        return player.get_active_hand_count() < this->effective_max_split_hands()
             && player.has_sufficient_funds(hand.get_bet())
             && cards[0].get_rank() == cards[1].get_rank();
     }
 
     [[nodiscard]] inline bool Game::can_surrender(uint8_t player_index, uint8_t hand_index) const noexcept {
+        if (!this->ruleset.surrender_allowed) {
+            return false;
+        }
+
         const Hand& hand = this->players[player_index].get_hand(hand_index);
 
         return this->is_first_action(player_index, hand_index)
             && hand.card_count() == 2
-            && hand.get_bet() > 0;
+            && hand.get_bet() > 0
+            && hand.get_origin() != HandOrigin::SPLIT;
     }
 
     [[nodiscard]] inline bool Game::is_hand_turn_complete(uint8_t player_index, uint8_t hand_index) const noexcept {
@@ -452,17 +508,6 @@ namespace blackjack::game {
         return dealer_hand.is_bust()
             || dealer_hand.is_blackjack()
             || this->dealer_hand_state.stood;
-    }
-
-    [[nodiscard]] inline LegalActions Game::make_legal_actions(
-        uint8_t player_index,
-        uint8_t hand_index
-    ) const noexcept {
-        return LegalActions{
-            this->can_double(player_index, hand_index),
-            this->can_split(player_index, hand_index),
-            this->can_surrender(player_index, hand_index),
-        };
     }
 
     void Game::play_round(uint64_t seed) noexcept {

--- a/simulator/include/blackjack/game/hand_round_state.hpp
+++ b/simulator/include/blackjack/game/hand_round_state.hpp
@@ -12,17 +12,20 @@ namespace blackjack::game {
         uint8_t action_count;
         bool stood;
         bool surrendered;
+        bool doubled;
 
         HandRoundState() noexcept
             : action_count(0)
             , stood(false)
             , surrendered(false)
+            , doubled(false)
         {}
 
         void reset() noexcept {
             this->action_count = 0;
             this->stood = false;
             this->surrendered = false;
+            this->doubled = false;
         }
     };
 }

--- a/simulator/include/blackjack/game/ruleset.hpp
+++ b/simulator/include/blackjack/game/ruleset.hpp
@@ -1,0 +1,47 @@
+#ifndef BLACKJACK_GAME_RULESET_HPP
+#define BLACKJACK_GAME_RULESET_HPP
+
+#include <cstdint>
+
+namespace blackjack::game {
+    class Ruleset {
+    public:
+        uint8_t blackjack_payout_num;
+        uint8_t blackjack_payout_denom;
+        bool dealer_hits_soft_17;
+        bool surrender_allowed;
+        bool double_after_split_allowed;
+        uint8_t max_split_hands;
+
+        static constexpr Ruleset default_vegas() noexcept {
+            return Ruleset(3, 2, false, true, true, 4);
+        }
+
+        static constexpr Ruleset tight_h17_no_surrender() noexcept {
+            return Ruleset(6, 5, true, false, false, 2);
+        }
+
+        [[nodiscard]] constexpr uint32_t calculate_blackjack_payout(uint32_t bet) const noexcept {
+            return bet + (bet * this->blackjack_payout_num / this->blackjack_payout_denom);
+        }
+
+    private:
+        constexpr Ruleset(
+            uint8_t bj_num,
+            uint8_t bj_denom,
+            bool dealer_hits_soft_17_,
+            bool surrender_allowed_,
+            bool double_after_split_allowed_,
+            uint8_t max_split_hands_
+        ) noexcept
+            : blackjack_payout_num(bj_num)
+            , blackjack_payout_denom(bj_denom)
+            , dealer_hits_soft_17(dealer_hits_soft_17_)
+            , surrender_allowed(surrender_allowed_)
+            , double_after_split_allowed(double_after_split_allowed_)
+            , max_split_hands(max_split_hands_)
+        {}
+    };
+}
+
+#endif

--- a/simulator/include/blackjack/hand/hand.hpp
+++ b/simulator/include/blackjack/hand/hand.hpp
@@ -47,6 +47,7 @@ namespace blackjack::hand {
         [[nodiscard]] inline bool is_surrendered() const noexcept;
 
         [[nodiscard]] inline uint8_t get_value() const noexcept;
+        [[nodiscard]] inline bool is_soft() const noexcept;
         [[nodiscard]] inline bool is_blackjack() const noexcept;
         [[nodiscard]] inline bool is_bust() const noexcept;
         [[nodiscard]] inline uint8_t card_count() const noexcept;
@@ -86,6 +87,25 @@ namespace blackjack::hand {
         }
 
         return value;
+    }
+
+    [[nodiscard]] inline bool Hand::is_soft() const noexcept {
+        uint8_t value = 0;
+        uint8_t aces_as_eleven = 0;
+
+        for (uint8_t i = 0; i < this->cards_in_hand; i++) {
+            value += this->cards[i].get_max_value();
+            if (this->cards[i].get_rank() == Rank::ACE) {
+                aces_as_eleven++;
+            }
+        }
+
+        while (aces_as_eleven > 0 && value > 21) {
+            value -= 10;
+            aces_as_eleven--;
+        }
+
+        return aces_as_eleven > 0;
     }
 
     [[nodiscard]] inline Card Hand::pop_card() noexcept {

--- a/simulator/include/blackjack/hand/hand.hpp
+++ b/simulator/include/blackjack/hand/hand.hpp
@@ -28,6 +28,7 @@ namespace blackjack::hand {
         uint8_t cards_in_hand;
         uint32_t bet_cents;
         HandOrigin origin;
+        bool surrendered;
 
     public:
         inline Hand() noexcept;
@@ -41,6 +42,9 @@ namespace blackjack::hand {
 
         inline void set_origin(HandOrigin new_origin) noexcept;
         [[nodiscard]] inline HandOrigin get_origin() const noexcept;
+
+        inline void set_surrendered(bool value) noexcept;
+        [[nodiscard]] inline bool is_surrendered() const noexcept;
 
         [[nodiscard]] inline uint8_t get_value() const noexcept;
         [[nodiscard]] inline bool is_blackjack() const noexcept;
@@ -57,6 +61,7 @@ namespace blackjack::hand {
         , cards_in_hand(0)
         , bet_cents(0)
         , origin(HandOrigin::NATURAL)
+        , surrendered(false)
     {}
 
     void Hand::add_card(const Card& card) noexcept {
@@ -92,6 +97,7 @@ namespace blackjack::hand {
         this->cards_in_hand = 0;
         this->bet_cents = 0;
         this->origin = HandOrigin::NATURAL;
+        this->surrendered = false;
     }
 
     void Hand::set_bet(uint32_t bet) noexcept {
@@ -108,6 +114,14 @@ namespace blackjack::hand {
 
     [[nodiscard]] inline HandOrigin Hand::get_origin() const noexcept {
         return this->origin;
+    }
+
+    void Hand::set_surrendered(bool value) noexcept {
+        this->surrendered = value;
+    }
+
+    [[nodiscard]] inline bool Hand::is_surrendered() const noexcept {
+        return this->surrendered;
     }
 
     [[nodiscard]] inline bool Hand::is_blackjack() const noexcept {

--- a/simulator/include/blackjack/hand/hand_outcome.hpp
+++ b/simulator/include/blackjack/hand/hand_outcome.hpp
@@ -12,6 +12,7 @@ namespace blackjack::hand {
         PLAYER_BUST_LOSS,
         DEALER_WIN_LOSS,
         DEALER_BLACKJACK_LOSS,
+        SURRENDER_LOSS,
 
         PUSH,
     };

--- a/simulator/include/blackjack/player/strategy/dealer.hpp
+++ b/simulator/include/blackjack/player/strategy/dealer.hpp
@@ -9,15 +9,27 @@ namespace blackjack::player::strategy {
     class DealerStrategy : public PlayerStrategy {
     private:
         static constexpr uint8_t DEALER_STAND_VALUE = 17;
+        bool hits_soft_17;
 
     public:
+        constexpr DealerStrategy() noexcept : hits_soft_17(false) {}
+        constexpr explicit DealerStrategy(bool hits_soft_17_) noexcept
+            : hits_soft_17(hits_soft_17_) {}
+
         [[nodiscard]] Decision get_decision(const GameContext& context) const noexcept override;
     };
 
     inline Decision DealerStrategy::get_decision(const GameContext& context) const noexcept {
-        return (context.get_own_hand().get_value() < this->DEALER_STAND_VALUE)
-            ? Decision::HIT
-            : Decision::STAND;
+        const auto& hand = context.get_own_hand();
+        uint8_t value = hand.get_value();
+
+        if (value < DEALER_STAND_VALUE) {
+            return Decision::HIT;
+        }
+        if (value == DEALER_STAND_VALUE && this->hits_soft_17 && hand.is_soft()) {
+            return Decision::HIT;
+        }
+        return Decision::STAND;
     }
 }
 

--- a/simulator/test/test_round.cpp
+++ b/simulator/test/test_round.cpp
@@ -1,5 +1,7 @@
 #include <blackjack/game/game.hpp>
 #include <blackjack/game/betting_config.hpp>
+#include <blackjack/hand/hand_origin.hpp>
+#include <blackjack/hand/hand_outcome.hpp>
 #include <blackjack/player/strategy/bearish.hpp>
 #include <blackjack/player/strategy/bullish.hpp>
 #include <blackjack/player/strategy/strategy.hpp>
@@ -16,8 +18,9 @@ using blackjack::game::ActionApplicationResult;
 using blackjack::game::BettingConfig;
 using blackjack::game::Game;
 using blackjack::hand::Hand;
+using blackjack::hand::HandOrigin;
+using blackjack::hand::HandOutcome;
 using blackjack::player::strategy::BearishStrategy;
-using blackjack::player::strategy::BullishStrategy;
 using blackjack::player::strategy::Decision;
 
 static Game make_game() {
@@ -112,7 +115,6 @@ TEST(RoundTest, SameSeedProducesDeterministicBankrollDelta) {
 }
 
 TEST(RoundTest, DifferentSeedsMayProduceDifferentOutcomes) {
-    // Run many seeds; at least one pair should differ (collision would be astronomically unlikely)
     bool found_difference = false;
 
     Game base = make_game();
@@ -225,14 +227,12 @@ TEST(RoundTest, ApplyDecisionOnInactiveHandIndexIsIllegal) {
         100
     );
 
-    // active_hand_count is 1, so hand_index 1..MAX-1 are all inactive.
     EXPECT_EQ(game.apply_decision(0, 1, Decision::HIT), ActionApplicationResult::ILLEGAL_ACTION);
     EXPECT_EQ(game.apply_decision(0, 1, Decision::STAND), ActionApplicationResult::ILLEGAL_ACTION);
 }
 
 TEST(RoundTest, HitUntilBustCompletesTurnAndRejectsFurtherActions) {
     Game game = make_game();
-    // Force a guaranteed-bust scenario: 10 + 6 + extra hits until value > 21.
     set_player_hand(
         game,
         0,
@@ -246,11 +246,384 @@ TEST(RoundTest, HitUntilBustCompletesTurnAndRejectsFurtherActions) {
         result = game.apply_decision(0, 0, Decision::HIT);
     }
 
-    // Whichever card busts the hand, the final HIT must report turn-complete.
     EXPECT_EQ(result, ActionApplicationResult::APPLIED_TURN_COMPLETE);
     EXPECT_TRUE(game.get_player(0).get_hand(0).is_bust());
 
-    // Subsequent actions on a completed hand are illegal.
     EXPECT_EQ(game.apply_decision(0, 0, Decision::HIT), ActionApplicationResult::ILLEGAL_ACTION);
     EXPECT_EQ(game.apply_decision(0, 0, Decision::STAND), ActionApplicationResult::ILLEGAL_ACTION);
+}
+
+static void set_dealer_hand(Game& game, Card first, Card second) {
+    auto& dealer = game.get_dealer();
+    dealer.clear_hand(0);
+    dealer.add_card_to_hand(0, first);
+    dealer.add_card_to_hand(0, second);
+}
+
+static void setup_hand_with_placed_bet(
+    Game& game,
+    uint8_t player_index,
+    Card first,
+    Card second,
+    uint32_t bet
+) {
+    auto& player = game.get_player(player_index);
+    player.clear_hand(0);
+    player.set_active_hand_count(1);
+    player.add_card_to_hand(0, first);
+    player.add_card_to_hand(0, second);
+    player.set_hand_bet(0, bet);
+    player.deduct_from_bankroll(bet);
+}
+
+static void replace_last_card(Hand& hand, Card replacement) {
+    (void) hand.pop_card();
+    hand.add_card(replacement);
+}
+
+TEST(ActionLifecycleTest, DoubleBlocksAllSubsequentActions) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::FIVE),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::DOUBLE), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::HIT),       ActionApplicationResult::ILLEGAL_ACTION);
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::STAND),     ActionApplicationResult::ILLEGAL_ACTION);
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::DOUBLE),    ActionApplicationResult::ILLEGAL_ACTION);
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::SPLIT),     ActionApplicationResult::ILLEGAL_ACTION);
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::SURRENDER), ActionApplicationResult::ILLEGAL_ACTION);
+}
+
+TEST(ActionLifecycleTest, DoubleWinPaysTwoToOneOnDoubledStake) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::FIVE),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::DOUBLE), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+    replace_last_card(game.get_player(0).get_hand(0), Card(Suit::CLUBS, Rank::NINE));
+    ASSERT_EQ(game.get_player(0).get_hand(0).get_value(), 20u);
+    ASSERT_EQ(game.get_player(0).get_hand(0).get_bet(), 200u);
+
+    set_dealer_hand(game, Card(Suit::DIAMONDS, Rank::NINE), Card(Suit::HEARTS, Rank::NINE));
+
+    game.resolve_hand(game.get_player(0), 0);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll + 200);
+}
+
+TEST(ActionLifecycleTest, DoubleLossLosesDoubledStake) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::FIVE),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::DOUBLE), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+    replace_last_card(game.get_player(0).get_hand(0), Card(Suit::CLUBS, Rank::FOUR));
+    ASSERT_EQ(game.get_player(0).get_hand(0).get_value(), 15u);
+
+    set_dealer_hand(game, Card(Suit::DIAMONDS, Rank::NINE), Card(Suit::HEARTS, Rank::NINE));
+
+    game.resolve_hand(game.get_player(0), 0);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll - 200);
+}
+
+TEST(ActionLifecycleTest, DoubleBustLosesDoubledStake) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::TEN),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::DOUBLE), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+    replace_last_card(game.get_player(0).get_hand(0), Card(Suit::CLUBS, Rank::KING));
+    ASSERT_TRUE(game.get_player(0).get_hand(0).is_bust());
+
+    set_dealer_hand(game, Card(Suit::DIAMONDS, Rank::NINE), Card(Suit::HEARTS, Rank::EIGHT));
+
+    game.resolve_hand(game.get_player(0), 0);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll - 200);
+}
+
+TEST(ActionLifecycleTest, DoublePushReturnsDoubledStake) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::FIVE),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::DOUBLE), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+    replace_last_card(game.get_player(0).get_hand(0), Card(Suit::CLUBS, Rank::SEVEN));
+    ASSERT_EQ(game.get_player(0).get_hand(0).get_value(), 18u);
+
+    set_dealer_hand(game, Card(Suit::DIAMONDS, Rank::NINE), Card(Suit::HEARTS, Rank::NINE));
+
+    game.resolve_hand(game.get_player(0), 0);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll);
+}
+
+TEST(ActionLifecycleTest, SurrenderBlocksAllSubsequentActions) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::TEN),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SURRENDER), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::HIT),       ActionApplicationResult::ILLEGAL_ACTION);
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::STAND),     ActionApplicationResult::ILLEGAL_ACTION);
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::DOUBLE),    ActionApplicationResult::ILLEGAL_ACTION);
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::SPLIT),     ActionApplicationResult::ILLEGAL_ACTION);
+    EXPECT_EQ(game.apply_decision(0, 0, Decision::SURRENDER), ActionApplicationResult::ILLEGAL_ACTION);
+}
+
+TEST(ActionLifecycleTest, SurrenderOutcomeReportsSurrenderLossWithZeroPayout) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::TEN),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SURRENDER), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+
+    const Hand& player_hand = game.get_player(0).get_hand(0);
+    Hand dealer_hand;
+    dealer_hand.add_card(Card(Suit::DIAMONDS, Rank::NINE));
+    dealer_hand.add_card(Card(Suit::CLUBS, Rank::NINE));
+
+    EXPECT_EQ(game.determine_outcome(player_hand, dealer_hand), HandOutcome::SURRENDER_LOSS);
+    EXPECT_EQ(game.calculate_payout(HandOutcome::SURRENDER_LOSS, 100), 0u);
+}
+
+TEST(ActionLifecycleTest, SurrenderSettlementSkipsRegularPayoutOnDealerBust) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::TEN),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SURRENDER), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+
+    set_dealer_hand(game, Card(Suit::DIAMONDS, Rank::KING), Card(Suit::CLUBS, Rank::KING));
+    game.get_dealer().add_card_to_hand(0, Card(Suit::HEARTS, Rank::FIVE));
+    ASSERT_TRUE(game.get_dealer().get_hand(0).is_bust());
+
+    game.resolve_hand(game.get_player(0), 0);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll - 50);
+    EXPECT_EQ(game.aggregate_statistics().get_hands_played(), 1u);
+}
+
+TEST(ActionLifecycleTest, SurrenderSettlementSkipsRegularPayoutOnDealerPush) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::TEN),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SURRENDER), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+
+    set_dealer_hand(game, Card(Suit::DIAMONDS, Rank::NINE), Card(Suit::CLUBS, Rank::SEVEN));
+
+    game.resolve_hand(game.get_player(0), 0);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll - 50);
+}
+
+TEST(ActionLifecycleTest, SurrenderSettlementSkipsRegularPayoutOnPlayerHigherValue) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::TEN),
+        Card(Suit::HEARTS, Rank::TEN), 
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SURRENDER), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+
+    set_dealer_hand(game, Card(Suit::DIAMONDS, Rank::NINE), Card(Suit::CLUBS, Rank::NINE));
+
+    game.resolve_hand(game.get_player(0), 0);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll - 50);
+}
+
+TEST(ActionLifecycleTest, SurrenderAgainstDealerBlackjackStillOnlyLosesHalf) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::TEN),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SURRENDER), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+
+    set_dealer_hand(game, Card(Suit::DIAMONDS, Rank::ACE), Card(Suit::CLUBS, Rank::KING));
+    ASSERT_TRUE(game.get_dealer().get_hand(0).is_blackjack());
+
+    game.resolve_hand(game.get_player(0), 0);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll - 50);
+}
+
+TEST(ActionLifecycleTest, SplitDeductsSecondBetAndMarksBothHandsSplitOrigin) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::EIGHT),
+        Card(Suit::HEARTS, Rank::EIGHT),
+        100
+    );
+    uint32_t bankroll_before_split = game.get_player(0).get_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SPLIT), ActionApplicationResult::APPLIED_CONTINUE);
+
+    auto& player = game.get_player(0);
+    EXPECT_EQ(player.get_bankroll(), bankroll_before_split - 100);
+    EXPECT_EQ(player.get_active_hand_count(), 2);
+    EXPECT_EQ(player.get_hand(0).get_bet(), 100u);
+    EXPECT_EQ(player.get_hand(1).get_bet(), 100u);
+    EXPECT_EQ(player.get_hand(0).get_origin(), HandOrigin::SPLIT);
+    EXPECT_EQ(player.get_hand(1).get_origin(), HandOrigin::SPLIT);
+}
+
+TEST(ActionLifecycleTest, SplitBothHandsWinSettledIndependently) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::EIGHT),
+        Card(Suit::HEARTS, Rank::EIGHT),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SPLIT), ActionApplicationResult::APPLIED_CONTINUE);
+
+    replace_last_card(game.get_player(0).get_hand(0), Card(Suit::CLUBS, Rank::TEN));
+    replace_last_card(game.get_player(0).get_hand(1), Card(Suit::DIAMONDS, Rank::TEN));
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::STAND), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+    ASSERT_EQ(game.apply_decision(0, 1, Decision::STAND), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+
+    set_dealer_hand(game, Card(Suit::HEARTS, Rank::TEN), Card(Suit::SPADES, Rank::SEVEN));
+
+    game.resolve_hand(game.get_player(0), 0);
+    game.resolve_hand(game.get_player(0), 1);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll + 200);
+    EXPECT_EQ(game.aggregate_statistics().get_hands_played(), 2u);
+}
+
+TEST(ActionLifecycleTest, SplitOneWinOneLossSettlesEachHandSeparately) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::EIGHT),
+        Card(Suit::HEARTS, Rank::EIGHT),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SPLIT), ActionApplicationResult::APPLIED_CONTINUE);
+
+    replace_last_card(game.get_player(0).get_hand(0), Card(Suit::CLUBS, Rank::TEN));
+    replace_last_card(game.get_player(0).get_hand(1), Card(Suit::DIAMONDS, Rank::FIVE));
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::STAND), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+    ASSERT_EQ(game.apply_decision(0, 1, Decision::STAND), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+
+    set_dealer_hand(game, Card(Suit::HEARTS, Rank::TEN), Card(Suit::SPADES, Rank::SEVEN));
+
+    game.resolve_hand(game.get_player(0), 0);
+    game.resolve_hand(game.get_player(0), 1);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll);
+    EXPECT_EQ(game.aggregate_statistics().get_hands_played(), 2u);
+}
+
+TEST(ActionLifecycleTest, SplitTwentyOneDoesNotPayBlackjackOdds) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::ACE),
+        Card(Suit::HEARTS, Rank::ACE),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SPLIT), ActionApplicationResult::APPLIED_CONTINUE);
+    replace_last_card(game.get_player(0).get_hand(0), Card(Suit::CLUBS, Rank::KING));
+    replace_last_card(game.get_player(0).get_hand(1), Card(Suit::DIAMONDS, Rank::QUEEN));
+
+    ASSERT_EQ(game.get_player(0).get_hand(0).get_value(), 21u);
+    ASSERT_EQ(game.get_player(0).get_hand(1).get_value(), 21u);
+
+    set_dealer_hand(game, Card(Suit::HEARTS, Rank::TEN), Card(Suit::SPADES, Rank::SEVEN));
+
+    game.resolve_hand(game.get_player(0), 0);
+    game.resolve_hand(game.get_player(0), 1);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll + 200);
+}
+
+TEST(ActionLifecycleTest, SplitHandBustOnlyLosesThatHandsStake) {
+    Game game = make_game();
+    setup_hand_with_placed_bet(
+        game, 0,
+        Card(Suit::SPADES, Rank::EIGHT),
+        Card(Suit::HEARTS, Rank::EIGHT),
+        100
+    );
+    uint32_t initial_bankroll = game.get_betting_config().get_initial_bankroll();
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SPLIT), ActionApplicationResult::APPLIED_CONTINUE);
+
+    replace_last_card(game.get_player(0).get_hand(0), Card(Suit::CLUBS, Rank::TEN));
+    replace_last_card(game.get_player(0).get_hand(1), Card(Suit::DIAMONDS, Rank::FIVE));
+
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::STAND), ActionApplicationResult::APPLIED_TURN_COMPLETE);
+    game.get_player(0).get_hand(1).add_card(Card(Suit::CLUBS, Rank::KING));
+    ASSERT_TRUE(game.get_player(0).get_hand(1).is_bust());
+
+    set_dealer_hand(game, Card(Suit::HEARTS, Rank::TEN), Card(Suit::SPADES, Rank::SEVEN));
+
+    game.resolve_hand(game.get_player(0), 0);
+    game.resolve_hand(game.get_player(0), 1);
+
+    EXPECT_EQ(game.get_player(0).get_bankroll(), initial_bankroll);
 }

--- a/simulator/test/test_rulesets.cpp
+++ b/simulator/test/test_rulesets.cpp
@@ -1,0 +1,318 @@
+#include <blackjack/card/card.hpp>
+#include <blackjack/game/betting_config.hpp>
+#include <blackjack/game/game.hpp>
+#include <blackjack/game/ruleset.hpp>
+#include <blackjack/hand/hand.hpp>
+#include <blackjack/hand/hand_origin.hpp>
+#include <blackjack/hand/hand_outcome.hpp>
+#include <blackjack/player/strategy/dealer.hpp>
+#include <blackjack/player/strategy/strategy.hpp>
+
+#include <gtest/gtest.h>
+
+using blackjack::card::Card;
+using blackjack::card::Rank;
+using blackjack::card::Suit;
+using blackjack::game::ActionApplicationResult;
+using blackjack::game::BettingConfig;
+using blackjack::game::Game;
+using blackjack::game::Ruleset;
+using blackjack::hand::Hand;
+using blackjack::hand::HandOrigin;
+using blackjack::hand::HandOutcome;
+using blackjack::player::strategy::DealerStrategy;
+using blackjack::player::strategy::Decision;
+using blackjack::player::strategy::GameContext;
+using blackjack::player::strategy::LegalActions;
+
+namespace {
+    Game make_game_with_rules(const Ruleset& rules) {
+        Game game(BettingConfig{}, rules);
+        game.initialize_round();
+        return game;
+    }
+
+    void seat_hand(
+        Game& game,
+        uint8_t player_index,
+        Card first,
+        Card second,
+        uint32_t bet,
+        HandOrigin origin = HandOrigin::NATURAL
+    ) {
+        auto& player = game.get_player(player_index);
+        player.clear_hand(0);
+        player.set_active_hand_count(1);
+        player.add_card_to_hand(0, first);
+        player.add_card_to_hand(0, second);
+        player.set_hand_bet(0, bet);
+        player.get_hand(0).set_origin(origin);
+        player.deduct_from_bankroll(bet);
+    }
+}
+
+TEST(RulesetTest, DefaultVegasFactoryMatchesHistoricalBehavior) {
+    Ruleset defaults = Ruleset::default_vegas();
+    EXPECT_EQ(defaults.blackjack_payout_num, 3);
+    EXPECT_EQ(defaults.blackjack_payout_denom, 2);
+    EXPECT_FALSE(defaults.dealer_hits_soft_17);
+    EXPECT_TRUE(defaults.surrender_allowed);
+    EXPECT_TRUE(defaults.double_after_split_allowed);
+    EXPECT_EQ(defaults.max_split_hands, 4);
+}
+
+TEST(RulesetTest, NamedFactoriesAreDistinguishable) {
+    Ruleset vegas = Ruleset::default_vegas();
+    Ruleset tight = Ruleset::tight_h17_no_surrender();
+
+    EXPECT_NE(vegas.blackjack_payout_num,        tight.blackjack_payout_num);
+    EXPECT_NE(vegas.dealer_hits_soft_17,         tight.dealer_hits_soft_17);
+    EXPECT_NE(vegas.surrender_allowed,           tight.surrender_allowed);
+    EXPECT_NE(vegas.double_after_split_allowed,  tight.double_after_split_allowed);
+    EXPECT_NE(vegas.max_split_hands,             tight.max_split_hands);
+}
+
+TEST(RulesetPayoutTest, BlackjackPays3to2UnderDefault) {
+    Game game = make_game_with_rules(Ruleset::default_vegas());
+    EXPECT_EQ(game.calculate_payout(HandOutcome::BLACKJACK_WIN, 1000), 2500u);
+}
+
+TEST(RulesetPayoutTest, BlackjackPays6to5UnderTightRuleset) {
+    Game game = make_game_with_rules(Ruleset::tight_h17_no_surrender());
+    EXPECT_EQ(game.calculate_payout(HandOutcome::BLACKJACK_WIN, 1000), 2200u);
+}
+
+TEST(RulesetPayoutTest, SameOutcomeYieldsDifferentPayoutsAcrossRulesets) {
+    Game vegas_game = make_game_with_rules(Ruleset::default_vegas());
+    Game tight_game = make_game_with_rules(Ruleset::tight_h17_no_surrender());
+
+    uint32_t vegas_payout = vegas_game.calculate_payout(HandOutcome::BLACKJACK_WIN, 1000);
+    uint32_t tight_payout = tight_game.calculate_payout(HandOutcome::BLACKJACK_WIN, 1000);
+
+    EXPECT_GT(vegas_payout, tight_payout);
+}
+
+TEST(RulesetLegalActionsTest, SurrenderLegalUnderDefault) {
+    Game game = make_game_with_rules(Ruleset::default_vegas());
+    seat_hand(game, 0,
+        Card(Suit::SPADES, Rank::TEN),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+
+    LegalActions legal = game.get_legal_actions(0, 0);
+    EXPECT_TRUE(legal.can_surrender);
+}
+
+TEST(RulesetLegalActionsTest, SurrenderIllegalWhenDisallowedByRuleset) {
+    Ruleset no_surrender = Ruleset::default_vegas();
+    no_surrender.surrender_allowed = false;
+
+    Game game = make_game_with_rules(no_surrender);
+    seat_hand(game, 0,
+        Card(Suit::SPADES, Rank::TEN),
+        Card(Suit::HEARTS, Rank::SIX),
+        100
+    );
+
+    LegalActions legal = game.get_legal_actions(0, 0);
+    EXPECT_FALSE(legal.can_surrender);
+    EXPECT_EQ(
+        game.apply_decision(0, 0, Decision::SURRENDER),
+        ActionApplicationResult::ILLEGAL_ACTION
+    );
+}
+
+TEST(RulesetLegalActionsTest, DoubleAfterSplitLegalUnderDefault) {
+    Game game = make_game_with_rules(Ruleset::default_vegas());
+    seat_hand(game, 0,
+        Card(Suit::SPADES, Rank::EIGHT),
+        Card(Suit::HEARTS, Rank::EIGHT),
+        100
+    );
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SPLIT), ActionApplicationResult::APPLIED_CONTINUE);
+
+    auto& post_split = game.get_player(0).get_hand(1);
+    (void) post_split.pop_card();
+    post_split.add_card(Card(Suit::CLUBS, Rank::THREE));
+
+    LegalActions legal = game.get_legal_actions(0, 1);
+    EXPECT_TRUE(legal.can_double)
+        << "Default ruleset must permit doubling on a post-split hand";
+}
+
+TEST(RulesetLegalActionsTest, DoubleAfterSplitIllegalWhenDisallowed) {
+    Ruleset no_das = Ruleset::default_vegas();
+    no_das.double_after_split_allowed = false;
+
+    Game game = make_game_with_rules(no_das);
+    seat_hand(game, 0,
+        Card(Suit::SPADES, Rank::EIGHT),
+        Card(Suit::HEARTS, Rank::EIGHT),
+        100
+    );
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SPLIT), ActionApplicationResult::APPLIED_CONTINUE);
+
+    auto& post_split = game.get_player(0).get_hand(1);
+    (void) post_split.pop_card();
+    post_split.add_card(Card(Suit::CLUBS, Rank::THREE));
+
+    LegalActions legal = game.get_legal_actions(0, 1);
+    EXPECT_FALSE(legal.can_double);
+    EXPECT_EQ(
+        game.apply_decision(0, 1, Decision::DOUBLE),
+        ActionApplicationResult::ILLEGAL_ACTION
+    );
+}
+
+TEST(RulesetLegalActionsTest, MaxSplitHandsCapsFurtherSplits) {
+    Ruleset two_split_max = Ruleset::default_vegas();
+    two_split_max.max_split_hands = 2;
+
+    Game game = make_game_with_rules(two_split_max);
+    seat_hand(game, 0,
+        Card(Suit::SPADES, Rank::EIGHT),
+        Card(Suit::HEARTS, Rank::EIGHT),
+        100
+    );
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SPLIT), ActionApplicationResult::APPLIED_CONTINUE);
+    ASSERT_EQ(game.get_player(0).get_active_hand_count(), 2);
+
+    auto& hand0 = game.get_player(0).get_hand(0);
+    (void) hand0.pop_card();
+    hand0.add_card(Card(Suit::DIAMONDS, Rank::EIGHT));
+
+    LegalActions legal = game.get_legal_actions(0, 0);
+    EXPECT_FALSE(legal.can_split)
+        << "Resplitting beyond max_split_hands must be disallowed";
+    EXPECT_EQ(
+        game.apply_decision(0, 0, Decision::SPLIT),
+        ActionApplicationResult::ILLEGAL_ACTION
+    );
+}
+
+TEST(RulesetLegalActionsTest, MaxSplitHandsFourAllowsResplit) {
+    Ruleset four_split_max = Ruleset::default_vegas();
+    four_split_max.max_split_hands = 4;
+
+    Game game = make_game_with_rules(four_split_max);
+    seat_hand(game, 0,
+        Card(Suit::SPADES, Rank::EIGHT),
+        Card(Suit::HEARTS, Rank::EIGHT),
+        100
+    );
+    ASSERT_EQ(game.apply_decision(0, 0, Decision::SPLIT), ActionApplicationResult::APPLIED_CONTINUE);
+
+    auto& hand0 = game.get_player(0).get_hand(0);
+    (void) hand0.pop_card();
+    hand0.add_card(Card(Suit::DIAMONDS, Rank::EIGHT));
+
+    LegalActions legal = game.get_legal_actions(0, 0);
+    EXPECT_TRUE(legal.can_split);
+}
+
+namespace {
+    Decision dealer_decision_for_soft_seventeen(bool hits_soft_17) {
+        DealerStrategy strategy(hits_soft_17);
+        Hand soft17;
+        soft17.add_card(Card(Suit::HEARTS, Rank::ACE));
+        soft17.add_card(Card(Suit::CLUBS, Rank::SIX));
+        Card upcard(Suit::SPADES, Rank::TEN);
+        GameContext ctx(soft17, upcard, LegalActions::none());
+        return strategy.get_decision(ctx);
+    }
+
+    Decision dealer_decision_for_hard_seventeen(bool hits_soft_17) {
+        DealerStrategy strategy(hits_soft_17);
+        Hand hard17;
+        hard17.add_card(Card(Suit::HEARTS, Rank::TEN));
+        hard17.add_card(Card(Suit::CLUBS, Rank::SEVEN));
+        Card upcard(Suit::SPADES, Rank::TEN);
+        GameContext ctx(hard17, upcard, LegalActions::none());
+        return strategy.get_decision(ctx);
+    }
+}
+
+TEST(RulesetDealerTest, DealerStandsOnSoft17UnderS17) {
+    EXPECT_EQ(dealer_decision_for_soft_seventeen(/*hits_soft_17=*/false), Decision::STAND);
+}
+
+TEST(RulesetDealerTest, DealerHitsSoft17UnderH17) {
+    EXPECT_EQ(dealer_decision_for_soft_seventeen(/*hits_soft_17=*/true), Decision::HIT);
+}
+
+TEST(RulesetDealerTest, DealerAlwaysStandsOnHard17) {
+    EXPECT_EQ(dealer_decision_for_hard_seventeen(/*hits_soft_17=*/false), Decision::STAND);
+    EXPECT_EQ(dealer_decision_for_hard_seventeen(/*hits_soft_17=*/true),  Decision::STAND);
+}
+
+TEST(RulesetDealerTest, DealerHitsBelowSeventeenRegardless) {
+    for (bool h17 : {false, true}) {
+        DealerStrategy strategy(h17);
+        Hand h;
+        h.add_card(Card(Suit::HEARTS, Rank::TEN));
+        h.add_card(Card(Suit::CLUBS, Rank::SIX));
+        Card upcard(Suit::SPADES, Rank::TEN);
+        GameContext ctx(h, upcard, LegalActions::none());
+        EXPECT_EQ(strategy.get_decision(ctx), Decision::HIT);
+    }
+}
+
+TEST(RulesetDealerTest, GameUsesDealerStrategyMatchingRuleset) {
+    Game s17_game(BettingConfig{}, Ruleset::default_vegas());
+    Game h17_game(BettingConfig{}, Ruleset::tight_h17_no_surrender());
+    EXPECT_FALSE(s17_game.get_ruleset().dealer_hits_soft_17);
+    EXPECT_TRUE(h17_game.get_ruleset().dealer_hits_soft_17);
+}
+
+TEST(RulesetEndToEndTest, SameSeedProducesDifferentDeltasAcrossRulesets) {
+    Game vegas(BettingConfig{}, Ruleset::default_vegas());
+    vegas.initialize_round();
+
+    Game tight(BettingConfig{}, Ruleset::tight_h17_no_surrender());
+    tight.initialize_round();
+
+    bool found_difference = false;
+    for (uint64_t seed = 1; seed <= 30 && !found_difference; seed++) {
+        Game v(BettingConfig{}, Ruleset::default_vegas());
+        v.initialize_round();
+        v.play_round(seed);
+
+        Game t(BettingConfig{}, Ruleset::tight_h17_no_surrender());
+        t.initialize_round();
+        t.play_round(seed);
+
+        if (v.aggregate_statistics().get_bankroll_delta()
+            != t.aggregate_statistics().get_bankroll_delta()) {
+            found_difference = true;
+        }
+    }
+
+    EXPECT_TRUE(found_difference)
+        << "At least one seed must produce distinguishable outcomes between rulesets";
+}
+
+TEST(HandSoftnessTest, SoftHandDetection) {
+    Hand h;
+    h.add_card(Card(Suit::SPADES, Rank::ACE));
+    h.add_card(Card(Suit::HEARTS, Rank::SIX));
+    EXPECT_TRUE(h.is_soft());
+    EXPECT_EQ(h.get_value(), 17u);
+}
+
+TEST(HandSoftnessTest, HardHandDetection) {
+    Hand h;
+    h.add_card(Card(Suit::SPADES, Rank::TEN));
+    h.add_card(Card(Suit::HEARTS, Rank::SEVEN));
+    EXPECT_FALSE(h.is_soft());
+    EXPECT_EQ(h.get_value(), 17u);
+}
+
+TEST(HandSoftnessTest, AceDemotedToOneIsHard) {
+    Hand h;
+    h.add_card(Card(Suit::SPADES, Rank::ACE));
+    h.add_card(Card(Suit::HEARTS, Rank::EIGHT));
+    h.add_card(Card(Suit::CLUBS, Rank::SEVEN));
+    EXPECT_FALSE(h.is_soft());
+    EXPECT_EQ(h.get_value(), 16u);
+}


### PR DESCRIPTION
## Notes
- Note: dependent on https://github.com/declspecl/csi4650/pull/19
- Move hardcoded legality and payout behavior out of Game so the simulator supports multiple rule variants cleanly

## Testing

- `./make.sh test`

```
Filename                         Regions    Missed Regions     Cover   Functions  Missed Functions  Executed       Lines      Missed Lines     Cover    Branches   Missed Branches     Cover
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
card/card.hpp                         12                 1    91.67%           5                 1    80.00%          22                 3    86.36%          10                 0   100.00%
deck/deck.hpp                         16                 6    62.50%           5                 1    80.00%          26                11    57.69%           2                 1    50.00%
deck/shoe.hpp                         12                 2    83.33%           4                 1    75.00%          20                 6    70.00%           4                 1    75.00%
game/betting_config.hpp               14                 1    92.86%           6                 1    83.33%          20                 3    85.00%           4                 2    50.00%
game/game.hpp                        212                 8    96.23%          28                 1    96.43%         346                14    95.95%         164                21    87.20%
game/game_statistics.hpp              12                 1    91.67%           6                 0   100.00%          24                 2    91.67%           2                 1    50.00%
game/hand_round_state.hpp              6                 0   100.00%           2                 0   100.00%          11                 0   100.00%           0                 0         -
game/ruleset.hpp                      10                 0   100.00%           4                 0   100.00%          16                 0   100.00%           0                 0         -
hand/hand.hpp                         59                10    83.05%          16                 0   100.00%          80                 0   100.00%          24                 2    91.67%
player/player.hpp                     27                 2    92.59%          16                 0   100.00%          59                 4    93.22%           4                 2    50.00%
player/strategy/bearish.hpp            4                 1    75.00%           1                 0   100.00%           5                 0   100.00%           2                 1    50.00%
player/strategy/bullish.hpp            1                 1     0.00%           1                 1     0.00%           5                 5     0.00%           0                 0         -
player/strategy/dealer.hpp            14                 1    92.86%           3                 1    66.67%          13                 1    92.31%           8                 0   100.00%
player/strategy/strategy.hpp          12                 5    58.33%           9                 5    44.44%          26                15    42.31%           0                 0         -
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                411                39    90.51%         106                12    88.68%         673                64    90.49%         224                31    86.16%
```