### PR TITLE
replace implicit dealer-strategy fallback with explicit player strategies

### DIFF
--- a/simulator/include/blackjack/game/game.hpp
+++ b/simulator/include/blackjack/game/game.hpp
@@ -396,7 +396,6 @@ namespace blackjack::game {
     void Game::play_turn_for_player(uint8_t player_index, uint8_t hand_index) noexcept {
         Player& player = this->players[player_index];
         PlayerStrategy* strategy = player.get_strategy();
-        PlayerStrategy* effective = strategy ? strategy : &this->dealer_strategy;
 
         while (!this->is_hand_turn_complete(player_index, hand_index)) {
             const Card& upcard = this->dealer.get_hand(0).get_cards_data()[1];
@@ -408,7 +407,7 @@ namespace blackjack::game {
             ActionApplicationResult result = this->apply_decision(
                 player_index,
                 hand_index,
-                effective->get_decision(ctx)
+                strategy->get_decision(ctx)
             );
 
             if (result == ActionApplicationResult::APPLIED_TURN_COMPLETE) {

--- a/simulator/include/blackjack/player/strategy/basic.hpp
+++ b/simulator/include/blackjack/player/strategy/basic.hpp
@@ -1,0 +1,182 @@
+#ifndef BLACKJACK_PLAYER_STRATEGY_BASIC_HPP
+#define BLACKJACK_PLAYER_STRATEGY_BASIC_HPP
+
+#include <blackjack/card/card.hpp>
+#include <blackjack/card/rank.hpp>
+#include <blackjack/hand/hand.hpp>
+#include <blackjack/player/strategy/strategy.hpp>
+
+#include <cstdint>
+
+namespace blackjack::player::strategy {
+    /**
+     * Textbook multi-deck basic strategy (S17, late surrender, DAS configurable).
+     */
+    class BasicStrategy : public PlayerStrategy {
+    private:
+        bool das_allowed;
+
+    public:
+        constexpr BasicStrategy() noexcept : das_allowed(true) {}
+        constexpr explicit BasicStrategy(bool double_after_split_allowed) noexcept
+            : das_allowed(double_after_split_allowed) {}
+
+        [[nodiscard]] Decision get_decision(const GameContext& context) const noexcept override;
+
+    private:
+        [[nodiscard]] static bool should_split(card::Rank pair_rank, uint8_t upcard_value, bool das) noexcept;
+        [[nodiscard]] static Decision soft_decision(uint8_t hand_value, uint8_t upcard_value, bool can_double) noexcept;
+        [[nodiscard]] static Decision hard_decision(uint8_t hand_value, uint8_t upcard_value, bool can_double, bool can_surrender) noexcept;
+    };
+
+    inline Decision BasicStrategy::get_decision(const GameContext& context) const noexcept {
+        const Hand& hand = context.get_own_hand();
+        uint8_t up = context.get_dealer_upcard().get_max_value();
+
+        if (context.can_split() && hand.card_count() == 2) {
+            const Card* cards = hand.get_cards_data();
+            card::Rank pair_rank = cards[0].get_rank();
+            bool is_pair = (pair_rank == cards[1].get_rank());
+            if (is_pair && should_split(pair_rank, up, this->das_allowed)) {
+                return Decision::SPLIT;
+            }
+        }
+
+        uint8_t value = hand.get_value();
+        if (hand.is_soft()) {
+            return soft_decision(value, up, context.can_double());
+        }
+        return hard_decision(value, up, context.can_double(), context.can_surrender());
+    }
+
+    inline bool BasicStrategy::should_split(card::Rank pair_rank, uint8_t up, bool das) noexcept {
+        switch (pair_rank) {
+            case card::Rank::ACE:
+            case card::Rank::EIGHT:
+                return true;
+
+            case card::Rank::NINE:
+                return !(up == 7 || up >= 10);
+
+            case card::Rank::SEVEN:
+                return up >= 2 && up <= 7;
+
+            case card::Rank::SIX:
+                return das ? (up >= 2 && up <= 6) : (up >= 3 && up <= 6);
+
+            case card::Rank::FOUR:
+                return das && (up == 5 || up == 6);
+
+            case card::Rank::THREE:
+            case card::Rank::TWO:
+                return das ? (up >= 2 && up <= 7) : (up >= 4 && up <= 7);
+
+            case card::Rank::FIVE:
+            case card::Rank::TEN:
+            case card::Rank::JACK:
+            case card::Rank::QUEEN:
+            case card::Rank::KING:
+                return false;
+        }
+        return false;
+    }
+
+    inline Decision BasicStrategy::soft_decision(uint8_t value, uint8_t up, bool can_double) noexcept {
+        switch (value) {
+            case 20:
+            case 21:
+                return Decision::STAND;
+
+            case 19:
+                return Decision::STAND;
+
+            case 18:
+                if (up >= 3 && up <= 6) {
+                    return can_double ? Decision::DOUBLE : Decision::STAND;
+                }
+                if (up == 2 || up == 7 || up == 8) {
+                    return Decision::STAND;
+                }
+                return Decision::HIT;
+
+            case 17:
+                if (up >= 3 && up <= 6) {
+                    return can_double ? Decision::DOUBLE : Decision::HIT;
+                }
+                return Decision::HIT;
+
+            case 16:
+            case 15:
+                if (up >= 4 && up <= 6) {
+                    return can_double ? Decision::DOUBLE : Decision::HIT;
+                }
+                return Decision::HIT;
+
+            case 14:
+            case 13:
+                if (up == 5 || up == 6) {
+                    return can_double ? Decision::DOUBLE : Decision::HIT;
+                }
+                return Decision::HIT;
+
+            default:
+                return Decision::HIT;
+        }
+    }
+
+    inline Decision BasicStrategy::hard_decision(uint8_t value, uint8_t up, bool can_double, bool can_surrender) noexcept {
+        if (value >= 17) {
+            return Decision::STAND;
+        }
+
+        if (value == 16) {
+            if (up >= 2 && up <= 6) {
+                return Decision::STAND;
+            }
+            if (can_surrender && (up == 9 || up == 10 || up == 11)) {
+                return Decision::SURRENDER;
+            }
+            return Decision::HIT;
+        }
+
+        if (value == 15) {
+            if (up >= 2 && up <= 6) {
+                return Decision::STAND;
+            }
+            if (can_surrender && up == 10) {
+                return Decision::SURRENDER;
+            }
+            return Decision::HIT;
+        }
+
+        if (value == 14 || value == 13) {
+            return (up >= 2 && up <= 6) ? Decision::STAND : Decision::HIT;
+        }
+
+        if (value == 12) {
+            return (up >= 4 && up <= 6) ? Decision::STAND : Decision::HIT;
+        }
+
+        if (value == 11) {
+            return can_double ? Decision::DOUBLE : Decision::HIT;
+        }
+
+        if (value == 10) {
+            if (up >= 2 && up <= 9) {
+                return can_double ? Decision::DOUBLE : Decision::HIT;
+            }
+            return Decision::HIT;
+        }
+
+        if (value == 9) {
+            if (up >= 3 && up <= 6) {
+                return can_double ? Decision::DOUBLE : Decision::HIT;
+            }
+            return Decision::HIT;
+        }
+
+        return Decision::HIT;
+    }
+}
+
+#endif

--- a/simulator/include/blackjack/player/strategy/mimic_dealer.hpp
+++ b/simulator/include/blackjack/player/strategy/mimic_dealer.hpp
@@ -1,0 +1,40 @@
+#ifndef BLACKJACK_PLAYER_STRATEGY_MIMIC_DEALER_HPP
+#define BLACKJACK_PLAYER_STRATEGY_MIMIC_DEALER_HPP
+
+#include <blackjack/player/strategy/strategy.hpp>
+
+#include <cstdint>
+
+namespace blackjack::player::strategy {
+    /**
+     * Plays a seated player like the dealer: hit until 17, optionally hitting
+     * soft 17. Never doubles, splits, or surrenders.
+     */
+    class MimicDealerStrategy : public PlayerStrategy {
+    private:
+        static constexpr uint8_t STAND_VALUE = 17;
+        bool hits_soft_17;
+
+    public:
+        constexpr MimicDealerStrategy() noexcept : hits_soft_17(false) {}
+        constexpr explicit MimicDealerStrategy(bool hits_soft_17_) noexcept
+            : hits_soft_17(hits_soft_17_) {}
+
+        [[nodiscard]] Decision get_decision(const GameContext& context) const noexcept override;
+    };
+
+    inline Decision MimicDealerStrategy::get_decision(const GameContext& context) const noexcept {
+        const auto& hand = context.get_own_hand();
+        uint8_t value = hand.get_value();
+
+        if (value < STAND_VALUE) {
+            return Decision::HIT;
+        }
+        if (value == STAND_VALUE && this->hits_soft_17 && hand.is_soft()) {
+            return Decision::HIT;
+        }
+        return Decision::STAND;
+    }
+}
+
+#endif

--- a/simulator/src/main.cpp
+++ b/simulator/src/main.cpp
@@ -1,9 +1,15 @@
-#include <blackjack/game/game.hpp>
 #include <blackjack/game/betting_config.hpp>
+#include <blackjack/game/game.hpp>
+#include <blackjack/player/strategy/basic.hpp>
+#include <blackjack/player/strategy/bearish.hpp>
+#include <blackjack/player/strategy/bullish.hpp>
+#include <blackjack/player/strategy/mimic_dealer.hpp>
+#include <blackjack/player/strategy/strategy.hpp>
 
 #include <chrono>
 #include <cstdlib>
 #include <iostream>
+#include <memory>
 #include <omp.h>
 #include <string_view>
 #include <vector>
@@ -11,22 +17,89 @@
 using blackjack::game::BettingConfig;
 using blackjack::game::Game;
 using blackjack::game::GameStatistics;
+using blackjack::player::strategy::BasicStrategy;
+using blackjack::player::strategy::BearishStrategy;
+using blackjack::player::strategy::BullishStrategy;
+using blackjack::player::strategy::MimicDealerStrategy;
+using blackjack::player::strategy::PlayerStrategy;
+
+enum class StrategyKind : uint8_t {
+    BASIC,
+    MIMIC_DEALER,
+    BEARISH,
+    BULLISH,
+};
 
 struct SimConfig {
-    uint32_t game_count      = 1000;
-    uint32_t rounds_per_game = 100;
-    int      threads         = omp_get_max_threads();
-    BettingConfig betting    = BettingConfig{};
+    uint32_t      game_count      = 1000;
+    uint32_t      rounds_per_game = 100;
+    int           threads         = omp_get_max_threads();
+    BettingConfig betting         = BettingConfig{};
+    StrategyKind  strategy        = StrategyKind::BASIC;
 };
+
+static std::string_view strategy_name(StrategyKind kind) noexcept {
+    switch (kind) {
+        case StrategyKind::BASIC:
+            return "basic";
+        case StrategyKind::MIMIC_DEALER:
+            return "mimic-dealer";
+        case StrategyKind::BEARISH:
+            return "bearish";
+        case StrategyKind::BULLISH:
+            return "bullish";
+    }
+    return "unknown";
+}
+
+static std::unique_ptr<PlayerStrategy> make_strategy(StrategyKind kind, bool das_allowed, bool h17) {
+    switch (kind) {
+        case StrategyKind::BASIC:
+            return std::make_unique<BasicStrategy>(das_allowed);
+        case StrategyKind::MIMIC_DEALER:
+            return std::make_unique<MimicDealerStrategy>(h17);
+        case StrategyKind::BEARISH:
+            return std::make_unique<BearishStrategy>();
+        case StrategyKind::BULLISH:
+            return std::make_unique<BullishStrategy>();
+    }
+    return nullptr;
+}
+
+static bool parse_strategy(std::string_view s, StrategyKind& out) {
+    if (s == "basic") {
+        out = StrategyKind::BASIC;
+        return true;
+    }
+    if (s == "mimic-dealer") {
+        out = StrategyKind::MIMIC_DEALER;
+        return true;
+    }
+    if (s == "bearish") {
+        out = StrategyKind::BEARISH;
+        return true;
+    }
+    if (s == "bullish") {
+        out = StrategyKind::BULLISH;
+        return true;
+    }
+    return false;
+}
 
 static void print_usage(const char* prog) {
     std::cerr << "Usage: " << prog << " [options]\n"
-              << "  --games    N   number of parallel games       (default: 1000)\n"
-              << "  --rounds   N   rounds per game                (default: 100)\n"
-              << "  --threads  N   OMP thread count               (default: max)\n"
-              << "  --min-bet  N   minimum bet in cents           (default: 100)\n"
-              << "  --max-bet  N   maximum bet in cents           (default: 10000)\n"
-              << "  --bankroll N   initial bankroll in cents      (default: 100000)\n";
+              << "  --games    N      number of parallel games     (default: 1000)\n"
+              << "  --rounds   N      rounds per game              (default: 100)\n"
+              << "  --threads  N      OMP thread count             (default: max)\n"
+              << "  --min-bet  N      minimum bet in cents         (default: 100)\n"
+              << "  --max-bet  N      maximum bet in cents         (default: 10000)\n"
+              << "  --bankroll N      initial bankroll in cents    (default: 100000)\n"
+              << "  --strategy NAME   player strategy (required to be explicit):\n"
+              << "                      basic         - textbook basic strategy (baseline)\n"
+              << "                      mimic-dealer  - play like the dealer (17 stand)\n"
+              << "                      bearish       - hit until 12, then stand\n"
+              << "                      bullish       - hit until 21\n"
+              << "                    (default: basic)\n";
 }
 
 static SimConfig parse_args(int argc, char* argv[]) {
@@ -37,6 +110,17 @@ static SimConfig parse_args(int argc, char* argv[]) {
 
     for (int i = 1; i < argc; i++) {
         std::string_view arg = argv[i];
+
+        if (arg == "--strategy" && i + 1 < argc) {
+            std::string_view name = argv[++i];
+            if (!parse_strategy(name, cfg.strategy)) {
+                std::cerr << "Unknown strategy: " << name << "\n";
+                print_usage(argv[0]);
+                std::exit(1);
+            }
+            continue;
+        }
+
         if ((arg == "--games" || arg == "--rounds" || arg == "--threads" ||
              arg == "--min-bet" || arg == "--max-bet" || arg == "--bankroll") && i + 1 < argc) {
             uint32_t val = static_cast<uint32_t>(std::atoi(argv[++i]));
@@ -57,12 +141,21 @@ static SimConfig parse_args(int argc, char* argv[]) {
     return cfg;
 }
 
+static void seat_players_with_strategy(Game& game, StrategyKind kind) {
+    bool das = game.get_ruleset().double_after_split_allowed;
+    bool h17 = game.get_ruleset().dealer_hits_soft_17;
+    for (uint8_t i = 0; i < Game::MAX_NON_DEALER_PLAYERS; i++) {
+        game.get_player(i).set_strategy(make_strategy(kind, das, h17));
+    }
+}
+
 static GameStatistics run_simulation(const SimConfig& cfg) {
     std::vector<Game> games;
     games.reserve(cfg.game_count);
     for (uint32_t g = 0; g < cfg.game_count; g++) {
         games.emplace_back(cfg.betting);
         games.back().initialize_round();
+        seat_players_with_strategy(games.back(), cfg.strategy);
     }
 
     uint64_t total_hands    = 0;
@@ -88,6 +181,7 @@ static GameStatistics run_simulation(const SimConfig& cfg) {
 }
 
 static void print_results(const SimConfig& cfg, const GameStatistics& stats, double ms) {
+    std::cout << "Strategy:          " << strategy_name(cfg.strategy) << "\n";
     std::cout << "Threads:           " << cfg.threads << "\n";
     std::cout << "Games:             " << cfg.game_count << "\n";
     std::cout << "Rounds per game:   " << cfg.rounds_per_game << "\n";

--- a/simulator/test/test_round.cpp
+++ b/simulator/test/test_round.cpp
@@ -4,6 +4,7 @@
 #include <blackjack/hand/hand_outcome.hpp>
 #include <blackjack/player/strategy/bearish.hpp>
 #include <blackjack/player/strategy/bullish.hpp>
+#include <blackjack/player/strategy/mimic_dealer.hpp>
 #include <blackjack/player/strategy/strategy.hpp>
 #include <blackjack/card/card.hpp>
 
@@ -22,11 +23,20 @@ using blackjack::hand::HandOrigin;
 using blackjack::hand::HandOutcome;
 using blackjack::player::strategy::BearishStrategy;
 using blackjack::player::strategy::Decision;
+using blackjack::player::strategy::MimicDealerStrategy;
+
+template <typename StrategyT>
+static void seat_all_players(Game& game) {
+    for (uint8_t i = 0; i < Game::MAX_NON_DEALER_PLAYERS; i++) {
+        game.get_player(i).set_strategy(std::make_unique<StrategyT>());
+    }
+}
 
 static Game make_game() {
     BettingConfig config;
     Game game(config);
     game.initialize_round();
+    seat_all_players<MimicDealerStrategy>(game);
     return game;
 }
 

--- a/simulator/test/test_rulesets.cpp
+++ b/simulator/test/test_rulesets.cpp
@@ -6,9 +6,12 @@
 #include <blackjack/hand/hand_origin.hpp>
 #include <blackjack/hand/hand_outcome.hpp>
 #include <blackjack/player/strategy/dealer.hpp>
+#include <blackjack/player/strategy/mimic_dealer.hpp>
 #include <blackjack/player/strategy/strategy.hpp>
 
 #include <gtest/gtest.h>
+
+#include <memory>
 
 using blackjack::card::Card;
 using blackjack::card::Rank;
@@ -24,11 +27,20 @@ using blackjack::player::strategy::DealerStrategy;
 using blackjack::player::strategy::Decision;
 using blackjack::player::strategy::GameContext;
 using blackjack::player::strategy::LegalActions;
+using blackjack::player::strategy::MimicDealerStrategy;
 
 namespace {
+    template <typename StrategyT>
+    void seat_all_players(Game& game) {
+        for (uint8_t i = 0; i < Game::MAX_NON_DEALER_PLAYERS; i++) {
+            game.get_player(i).set_strategy(std::make_unique<StrategyT>());
+        }
+    }
+
     Game make_game_with_rules(const Ruleset& rules) {
         Game game(BettingConfig{}, rules);
         game.initialize_round();
+        seat_all_players<MimicDealerStrategy>(game);
         return game;
     }
 
@@ -266,20 +278,16 @@ TEST(RulesetDealerTest, GameUsesDealerStrategyMatchingRuleset) {
 }
 
 TEST(RulesetEndToEndTest, SameSeedProducesDifferentDeltasAcrossRulesets) {
-    Game vegas(BettingConfig{}, Ruleset::default_vegas());
-    vegas.initialize_round();
-
-    Game tight(BettingConfig{}, Ruleset::tight_h17_no_surrender());
-    tight.initialize_round();
-
     bool found_difference = false;
     for (uint64_t seed = 1; seed <= 30 && !found_difference; seed++) {
         Game v(BettingConfig{}, Ruleset::default_vegas());
         v.initialize_round();
+        seat_all_players<MimicDealerStrategy>(v);
         v.play_round(seed);
 
         Game t(BettingConfig{}, Ruleset::tight_h17_no_surrender());
         t.initialize_round();
+        seat_all_players<MimicDealerStrategy>(t);
         t.play_round(seed);
 
         if (v.aggregate_statistics().get_bankroll_delta()

--- a/simulator/test/test_strategies.cpp
+++ b/simulator/test/test_strategies.cpp
@@ -1,0 +1,311 @@
+#include <blackjack/card/card.hpp>
+#include <blackjack/card/rank.hpp>
+#include <blackjack/card/suit.hpp>
+#include <blackjack/game/betting_config.hpp>
+#include <blackjack/game/game.hpp>
+#include <blackjack/game/ruleset.hpp>
+#include <blackjack/hand/hand.hpp>
+#include <blackjack/player/strategy/basic.hpp>
+#include <blackjack/player/strategy/bearish.hpp>
+#include <blackjack/player/strategy/bullish.hpp>
+#include <blackjack/player/strategy/mimic_dealer.hpp>
+#include <blackjack/player/strategy/strategy.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using blackjack::card::Card;
+using blackjack::card::Rank;
+using blackjack::card::Suit;
+using blackjack::game::BettingConfig;
+using blackjack::game::Game;
+using blackjack::game::Ruleset;
+using blackjack::hand::Hand;
+using blackjack::player::strategy::BasicStrategy;
+using blackjack::player::strategy::BearishStrategy;
+using blackjack::player::strategy::BullishStrategy;
+using blackjack::player::strategy::Decision;
+using blackjack::player::strategy::GameContext;
+using blackjack::player::strategy::LegalActions;
+using blackjack::player::strategy::MimicDealerStrategy;
+using blackjack::player::strategy::PlayerStrategy;
+
+namespace {
+    Hand make_hand(Card a, Card b) {
+        Hand h;
+        h.add_card(a);
+        h.add_card(b);
+        return h;
+    }
+
+    GameContext ctx(const Hand& hand, Card upcard, LegalActions legal) {
+        return GameContext(hand, upcard, legal);
+    }
+
+    constexpr LegalActions all_legal()          { return LegalActions{true,  true,  true};  }
+    constexpr LegalActions only_hit_stand()     { return LegalActions{false, false, false}; }
+    constexpr LegalActions can_double_only()    { return LegalActions{true,  false, false}; }
+    constexpr LegalActions can_surrender_only() { return LegalActions{false, false, true};  }
+}
+
+TEST(MimicDealerStrategyTest, HitsBelow17) {
+    MimicDealerStrategy s;
+    Hand hand = make_hand(Card(Suit::SPADES, Rank::TEN), Card(Suit::HEARTS, Rank::SIX));
+    EXPECT_EQ(s.get_decision(ctx(hand, Card(Suit::CLUBS, Rank::SIX), all_legal())), Decision::HIT);
+}
+
+TEST(MimicDealerStrategyTest, StandsAtHard17) {
+    MimicDealerStrategy s;
+    Hand hand = make_hand(Card(Suit::SPADES, Rank::TEN), Card(Suit::HEARTS, Rank::SEVEN));
+    EXPECT_EQ(s.get_decision(ctx(hand, Card(Suit::CLUBS, Rank::SIX), all_legal())), Decision::STAND);
+}
+
+TEST(MimicDealerStrategyTest, StandsOnSoft17WhenS17) {
+    MimicDealerStrategy s(/*hits_soft_17=*/false);
+    Hand hand = make_hand(Card(Suit::SPADES, Rank::ACE), Card(Suit::HEARTS, Rank::SIX));
+    EXPECT_EQ(s.get_decision(ctx(hand, Card(Suit::CLUBS, Rank::TEN), all_legal())), Decision::STAND);
+}
+
+TEST(MimicDealerStrategyTest, HitsOnSoft17WhenH17) {
+    MimicDealerStrategy s(/*hits_soft_17=*/true);
+    Hand hand = make_hand(Card(Suit::SPADES, Rank::ACE), Card(Suit::HEARTS, Rank::SIX));
+    EXPECT_EQ(s.get_decision(ctx(hand, Card(Suit::CLUBS, Rank::TEN), all_legal())), Decision::HIT);
+}
+
+TEST(MimicDealerStrategyTest, NeverDoublesSplitsOrSurrendersEvenWhenLegal) {
+    MimicDealerStrategy s;
+    Hand eleven = make_hand(Card(Suit::SPADES, Rank::SIX), Card(Suit::HEARTS, Rank::FIVE));
+    Hand pair_eights = make_hand(Card(Suit::SPADES, Rank::EIGHT), Card(Suit::HEARTS, Rank::EIGHT));
+    Hand sixteen = make_hand(Card(Suit::SPADES, Rank::TEN), Card(Suit::HEARTS, Rank::SIX));
+
+    EXPECT_EQ(s.get_decision(ctx(eleven, Card(Suit::CLUBS, Rank::SIX), all_legal())), Decision::HIT);
+    EXPECT_NE(s.get_decision(ctx(pair_eights, Card(Suit::CLUBS, Rank::TEN), all_legal())), Decision::SPLIT);
+    EXPECT_NE(s.get_decision(ctx(sixteen, Card(Suit::CLUBS, Rank::TEN), all_legal())), Decision::SURRENDER);
+}
+
+TEST(BasicStrategyTest, HitsHard8) {
+    BasicStrategy s;
+    Hand hand = make_hand(Card(Suit::SPADES, Rank::FIVE), Card(Suit::HEARTS, Rank::THREE));
+    for (uint8_t up = 2; up <= 11; up++) {
+        Rank rank = (up == 11) ? Rank::ACE : static_cast<Rank>(up);
+        Card upcard(Suit::CLUBS, rank);
+        EXPECT_EQ(s.get_decision(ctx(hand, upcard, all_legal())), Decision::HIT)
+            << "hard 8 vs up=" << int(up);
+    }
+}
+
+TEST(BasicStrategyTest, DoublesHard11WhenAllowed) {
+    BasicStrategy s;
+    Hand hand = make_hand(Card(Suit::SPADES, Rank::SIX), Card(Suit::HEARTS, Rank::FIVE));
+    EXPECT_EQ(s.get_decision(ctx(hand, Card(Suit::CLUBS, Rank::TEN), can_double_only())), Decision::DOUBLE);
+    EXPECT_EQ(s.get_decision(ctx(hand, Card(Suit::CLUBS, Rank::ACE), can_double_only())), Decision::DOUBLE);
+}
+
+TEST(BasicStrategyTest, FallsBackToHitWhenDoubleIllegal) {
+    BasicStrategy s;
+    Hand hand = make_hand(Card(Suit::SPADES, Rank::SIX), Card(Suit::HEARTS, Rank::FIVE));
+    EXPECT_EQ(s.get_decision(ctx(hand, Card(Suit::CLUBS, Rank::TEN), only_hit_stand())), Decision::HIT);
+}
+
+TEST(BasicStrategyTest, DoublesHard10OnlyAgainstTwoThroughNine) {
+    BasicStrategy s;
+    Hand hand = make_hand(Card(Suit::SPADES, Rank::SEVEN), Card(Suit::HEARTS, Rank::THREE));
+    for (uint8_t up = 2; up <= 9; up++) {
+        Card upcard(Suit::CLUBS, static_cast<Rank>(up));
+        EXPECT_EQ(s.get_decision(ctx(hand, upcard, can_double_only())), Decision::DOUBLE)
+            << "hard 10 vs up=" << int(up);
+    }
+    EXPECT_EQ(s.get_decision(ctx(hand, Card(Suit::CLUBS, Rank::TEN), can_double_only())), Decision::HIT);
+    EXPECT_EQ(s.get_decision(ctx(hand, Card(Suit::CLUBS, Rank::ACE), can_double_only())), Decision::HIT);
+}
+
+TEST(BasicStrategyTest, StandsOnStiffAgainstBustCards) {
+    BasicStrategy s;
+    Hand thirteen = make_hand(Card(Suit::SPADES, Rank::EIGHT), Card(Suit::HEARTS, Rank::FIVE));
+    Hand sixteen  = make_hand(Card(Suit::SPADES, Rank::TEN),   Card(Suit::HEARTS, Rank::SIX));
+
+    for (uint8_t up = 2; up <= 6; up++) {
+        Card upcard(Suit::CLUBS, static_cast<Rank>(up));
+        if (up >= 4) {
+            EXPECT_EQ(s.get_decision(ctx(thirteen, upcard, all_legal())), Decision::STAND);
+        }
+        EXPECT_EQ(s.get_decision(ctx(sixteen, upcard, all_legal())), Decision::STAND);
+    }
+}
+
+TEST(BasicStrategyTest, HitsTwelveAgainstDealerTwoAndThree) {
+    BasicStrategy s;
+    Hand twelve = make_hand(Card(Suit::SPADES, Rank::SEVEN), Card(Suit::HEARTS, Rank::FIVE));
+    EXPECT_EQ(s.get_decision(ctx(twelve, Card(Suit::CLUBS, Rank::TWO), all_legal())), Decision::HIT);
+    EXPECT_EQ(s.get_decision(ctx(twelve, Card(Suit::CLUBS, Rank::THREE), all_legal())), Decision::HIT);
+    EXPECT_EQ(s.get_decision(ctx(twelve, Card(Suit::CLUBS, Rank::FOUR), all_legal())), Decision::STAND);
+}
+
+TEST(BasicStrategyTest, SurrendersSixteenAgainstStrongUpcardsWhenAllowed) {
+    BasicStrategy s;
+    Hand sixteen = make_hand(Card(Suit::SPADES, Rank::TEN), Card(Suit::HEARTS, Rank::SIX));
+
+    EXPECT_EQ(s.get_decision(ctx(sixteen, Card(Suit::CLUBS, Rank::NINE), can_surrender_only())), Decision::SURRENDER);
+    EXPECT_EQ(s.get_decision(ctx(sixteen, Card(Suit::CLUBS, Rank::TEN),  can_surrender_only())), Decision::SURRENDER);
+    EXPECT_EQ(s.get_decision(ctx(sixteen, Card(Suit::CLUBS, Rank::ACE),  can_surrender_only())), Decision::SURRENDER);
+}
+
+TEST(BasicStrategyTest, FallsBackToHitSixteenWhenSurrenderDisallowed) {
+    BasicStrategy s;
+    Hand sixteen = make_hand(Card(Suit::SPADES, Rank::TEN), Card(Suit::HEARTS, Rank::SIX));
+    EXPECT_EQ(s.get_decision(ctx(sixteen, Card(Suit::CLUBS, Rank::TEN), only_hit_stand())), Decision::HIT);
+}
+
+TEST(BasicStrategyTest, SurrendersFifteenOnlyAgainstTen) {
+    BasicStrategy s;
+    Hand fifteen = make_hand(Card(Suit::SPADES, Rank::TEN), Card(Suit::HEARTS, Rank::FIVE));
+    EXPECT_EQ(s.get_decision(ctx(fifteen, Card(Suit::CLUBS, Rank::TEN),  can_surrender_only())), Decision::SURRENDER);
+    EXPECT_EQ(s.get_decision(ctx(fifteen, Card(Suit::CLUBS, Rank::NINE), can_surrender_only())), Decision::HIT);
+    EXPECT_EQ(s.get_decision(ctx(fifteen, Card(Suit::CLUBS, Rank::ACE),  can_surrender_only())), Decision::HIT);
+}
+
+TEST(BasicStrategyTest, AlwaysSplitsAcesAndEights) {
+    BasicStrategy s;
+    Hand aces   = make_hand(Card(Suit::SPADES, Rank::ACE),   Card(Suit::HEARTS, Rank::ACE));
+    Hand eights = make_hand(Card(Suit::SPADES, Rank::EIGHT), Card(Suit::HEARTS, Rank::EIGHT));
+
+    for (uint8_t up = 2; up <= 11; up++) {
+        Rank rank = (up == 11) ? Rank::ACE : static_cast<Rank>(up);
+        Card upcard(Suit::CLUBS, rank);
+        EXPECT_EQ(s.get_decision(ctx(aces,   upcard, all_legal())), Decision::SPLIT);
+        EXPECT_EQ(s.get_decision(ctx(eights, upcard, all_legal())), Decision::SPLIT);
+    }
+}
+
+TEST(BasicStrategyTest, NeverSplitsTens) {
+    BasicStrategy s;
+    Hand tens = make_hand(Card(Suit::SPADES, Rank::TEN), Card(Suit::HEARTS, Rank::TEN));
+    for (uint8_t up = 2; up <= 11; up++) {
+        Rank rank = (up == 11) ? Rank::ACE : static_cast<Rank>(up);
+        Card upcard(Suit::CLUBS, rank);
+        EXPECT_EQ(s.get_decision(ctx(tens, upcard, all_legal())), Decision::STAND);
+    }
+}
+
+TEST(BasicStrategyTest, NeverSplitsFivesTreatsThemAsHardTen) {
+    BasicStrategy s;
+    Hand fives = make_hand(Card(Suit::SPADES, Rank::FIVE), Card(Suit::HEARTS, Rank::FIVE));
+
+    EXPECT_EQ(s.get_decision(ctx(fives, Card(Suit::CLUBS, Rank::SIX),  all_legal())), Decision::DOUBLE);
+    EXPECT_EQ(s.get_decision(ctx(fives, Card(Suit::CLUBS, Rank::TEN),  all_legal())), Decision::HIT);
+    EXPECT_EQ(s.get_decision(ctx(fives, Card(Suit::CLUBS, Rank::ACE),  all_legal())), Decision::HIT);
+}
+
+TEST(BasicStrategyTest, SplitsNinesExceptAgainstSevenTenAndAce) {
+    BasicStrategy s;
+    Hand nines = make_hand(Card(Suit::SPADES, Rank::NINE), Card(Suit::HEARTS, Rank::NINE));
+
+    EXPECT_EQ(s.get_decision(ctx(nines, Card(Suit::CLUBS, Rank::SIX),   all_legal())), Decision::SPLIT);
+    EXPECT_EQ(s.get_decision(ctx(nines, Card(Suit::CLUBS, Rank::SEVEN), all_legal())), Decision::STAND);
+    EXPECT_EQ(s.get_decision(ctx(nines, Card(Suit::CLUBS, Rank::EIGHT), all_legal())), Decision::SPLIT);
+    EXPECT_EQ(s.get_decision(ctx(nines, Card(Suit::CLUBS, Rank::TEN),   all_legal())), Decision::STAND);
+    EXPECT_EQ(s.get_decision(ctx(nines, Card(Suit::CLUBS, Rank::ACE),   all_legal())), Decision::STAND);
+}
+
+TEST(BasicStrategyTest, SoftEighteenDoublesVsWeakStandsVsMediumHitsVsStrong) {
+    BasicStrategy s;
+    Hand soft18 = make_hand(Card(Suit::SPADES, Rank::ACE), Card(Suit::HEARTS, Rank::SEVEN));
+
+    EXPECT_EQ(s.get_decision(ctx(soft18, Card(Suit::CLUBS, Rank::TWO),   can_double_only())), Decision::STAND);
+    EXPECT_EQ(s.get_decision(ctx(soft18, Card(Suit::CLUBS, Rank::FOUR),  can_double_only())), Decision::DOUBLE);
+    EXPECT_EQ(s.get_decision(ctx(soft18, Card(Suit::CLUBS, Rank::SEVEN), can_double_only())), Decision::STAND);
+    EXPECT_EQ(s.get_decision(ctx(soft18, Card(Suit::CLUBS, Rank::NINE),  can_double_only())), Decision::HIT);
+    EXPECT_EQ(s.get_decision(ctx(soft18, Card(Suit::CLUBS, Rank::ACE),   can_double_only())), Decision::HIT);
+}
+
+TEST(BasicStrategyTest, StandsOnSoft19AndSoft20) {
+    BasicStrategy s;
+    Hand soft19 = make_hand(Card(Suit::SPADES, Rank::ACE), Card(Suit::HEARTS, Rank::EIGHT));
+    Hand soft20 = make_hand(Card(Suit::SPADES, Rank::ACE), Card(Suit::HEARTS, Rank::NINE));
+    for (uint8_t up = 2; up <= 11; up++) {
+        Rank rank = (up == 11) ? Rank::ACE : static_cast<Rank>(up);
+        Card upcard(Suit::CLUBS, rank);
+        EXPECT_EQ(s.get_decision(ctx(soft19, upcard, all_legal())), Decision::STAND);
+        EXPECT_EQ(s.get_decision(ctx(soft20, upcard, all_legal())), Decision::STAND);
+    }
+}
+
+TEST(BasicStrategyTest, OnlySplitsFoursAgainstFiveAndSixWhenDasAllowed) {
+    BasicStrategy das_on(true);
+    BasicStrategy das_off(false);
+    Hand fours = make_hand(Card(Suit::SPADES, Rank::FOUR), Card(Suit::HEARTS, Rank::FOUR));
+
+    EXPECT_EQ(das_on.get_decision(ctx(fours, Card(Suit::CLUBS, Rank::FIVE), all_legal())), Decision::SPLIT);
+    EXPECT_EQ(das_on.get_decision(ctx(fours, Card(Suit::CLUBS, Rank::SIX),  all_legal())), Decision::SPLIT);
+    EXPECT_EQ(das_on.get_decision(ctx(fours, Card(Suit::CLUBS, Rank::FOUR), all_legal())), Decision::HIT);
+
+    EXPECT_EQ(das_off.get_decision(ctx(fours, Card(Suit::CLUBS, Rank::FIVE), all_legal())), Decision::HIT);
+    EXPECT_EQ(das_off.get_decision(ctx(fours, Card(Suit::CLUBS, Rank::SIX),  all_legal())), Decision::HIT);
+}
+
+TEST(BearishStrategyTest, HitsBelowTwelveAndStandsOtherwise) {
+    BearishStrategy s;
+    Hand eleven = make_hand(Card(Suit::SPADES, Rank::SIX), Card(Suit::HEARTS, Rank::FIVE));
+    Hand twelve = make_hand(Card(Suit::SPADES, Rank::SEVEN), Card(Suit::HEARTS, Rank::FIVE));
+    Hand seventeen = make_hand(Card(Suit::SPADES, Rank::TEN), Card(Suit::HEARTS, Rank::SEVEN));
+
+    EXPECT_EQ(s.get_decision(ctx(eleven,    Card(Suit::CLUBS, Rank::TEN), all_legal())), Decision::HIT);
+    EXPECT_EQ(s.get_decision(ctx(twelve,    Card(Suit::CLUBS, Rank::TEN), all_legal())), Decision::STAND);
+    EXPECT_EQ(s.get_decision(ctx(seventeen, Card(Suit::CLUBS, Rank::TEN), all_legal())), Decision::STAND);
+}
+
+TEST(BullishStrategyTest, HitsUntilTwentyOne) {
+    BullishStrategy s;
+    Hand twenty = make_hand(Card(Suit::SPADES, Rank::TEN), Card(Suit::HEARTS, Rank::TEN));
+    Hand five   = make_hand(Card(Suit::SPADES, Rank::THREE), Card(Suit::HEARTS, Rank::TWO));
+
+    EXPECT_EQ(s.get_decision(ctx(twenty, Card(Suit::CLUBS, Rank::TEN), all_legal())), Decision::HIT);
+    EXPECT_EQ(s.get_decision(ctx(five,   Card(Suit::CLUBS, Rank::TEN), all_legal())), Decision::HIT);
+}
+
+namespace {
+    int64_t delta_with_strategy(auto factory, uint64_t seed) {
+        Game game(BettingConfig{}, Ruleset::default_vegas());
+        game.initialize_round();
+        for (uint8_t i = 0; i < Game::MAX_NON_DEALER_PLAYERS; i++) {
+            game.get_player(i).set_strategy(factory());
+        }
+        game.play_round(seed);
+        return game.aggregate_statistics().get_bankroll_delta();
+    }
+}
+
+TEST(StrategySelectionTest, DifferentStrategiesProduceDifferentOutcomesOnSameSeed) {
+    bool found_difference = false;
+    for (uint64_t seed = 1; seed <= 30 && !found_difference; seed++) {
+        int64_t basic   = delta_with_strategy([]{ return std::make_unique<BasicStrategy>();        }, seed);
+        int64_t mimic   = delta_with_strategy([]{ return std::make_unique<MimicDealerStrategy>();  }, seed);
+        int64_t bullish = delta_with_strategy([]{ return std::make_unique<BullishStrategy>();      }, seed);
+
+        if (basic != mimic || basic != bullish || mimic != bullish) {
+            found_difference = true;
+        }
+    }
+    EXPECT_TRUE(found_difference);
+}
+
+TEST(StrategySelectionTest, SameStrategyOnSameSeedIsDeterministic) {
+    int64_t a = delta_with_strategy([]{ return std::make_unique<BasicStrategy>(); }, 7);
+    int64_t b = delta_with_strategy([]{ return std::make_unique<BasicStrategy>(); }, 7);
+    EXPECT_EQ(a, b);
+}
+
+TEST(StrategySelectionTest, PlayerStrategyIsWhatTheCallerSets) {
+    Game game(BettingConfig{}, Ruleset::default_vegas());
+    game.initialize_round();
+
+    for (uint8_t i = 0; i < Game::MAX_NON_DEALER_PLAYERS; i++) {
+        game.get_player(i).set_strategy(std::make_unique<BearishStrategy>());
+    }
+    for (uint8_t i = 0; i < Game::MAX_NON_DEALER_PLAYERS; i++) {
+        PlayerStrategy* assigned = game.get_player(i).get_strategy();
+        ASSERT_NE(assigned, nullptr);
+        EXPECT_NE(dynamic_cast<BearishStrategy*>(assigned), nullptr);
+    }
+}


### PR DESCRIPTION
## Notes

- previously Game::play_turn_for_player silently substituted the dealer
strategy for any player without one, so production runs were driven by
an unintentional default. Require callers to install a strategy, add a
baseline (BasicStrategy) that consults dealer up-card and legal actions,
and an explicit alternate (MimicDealerStrategy) that replaces the old
fallback. main.cpp now selects one via --strategy; tests seat strategies
explicitly.

## Testing

- `./make.sh test`

```
Filename                             Regions    Missed Regions     Cover   Functions  Missed Functions  Executed       Lines      Missed Lines     Cover    Branches   Missed Branches     Cover
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
card/card.hpp                             12                 1    91.67%           5                 1    80.00%          22                 3    86.36%          10                 0   100.00%
deck/deck.hpp                             16                 6    62.50%           5                 1    80.00%          26                11    57.69%           2                 1    50.00%
deck/shoe.hpp                             12                 2    83.33%           4                 1    75.00%          20                 6    70.00%           4                 1    75.00%
game/betting_config.hpp                   14                 1    92.86%           6                 1    83.33%          20                 3    85.00%           4                 2    50.00%
game/game.hpp                            209                 8    96.17%          28                 1    96.43%         345                14    95.94%         162                21    87.04%
game/game_statistics.hpp                  12                 1    91.67%           6                 0   100.00%          24                 2    91.67%           2                 1    50.00%
game/hand_round_state.hpp                  6                 0   100.00%           2                 0   100.00%          11                 0   100.00%           0                 0         -
game/ruleset.hpp                          10                 0   100.00%           4                 0   100.00%          16                 0   100.00%           0                 0         -
hand/hand.hpp                             59                10    83.05%          16                 0   100.00%          80                 0   100.00%          24                 2    91.67%
player/player.hpp                         27                 2    92.59%          16                 0   100.00%          59                 4    93.22%           4                 2    50.00%
player/strategy/basic.hpp                184                51    72.28%           6                 0   100.00%         125                25    80.00%         182                67    63.19%
player/strategy/bearish.hpp                4                 0   100.00%           1                 0   100.00%           5                 0   100.00%           2                 0   100.00%
player/strategy/bullish.hpp                4                 0   100.00%           1                 0   100.00%           5                 0   100.00%           2                 0   100.00%
player/strategy/dealer.hpp                14                 1    92.86%           3                 1    66.67%          13                 1    92.31%           8                 0   100.00%
player/strategy/mimic_dealer.hpp          15                 0   100.00%           3                 0   100.00%          13                 0   100.00%           8                 1    87.50%
player/strategy/strategy.hpp              12                 1    91.67%           9                 1    88.89%          26                 3    88.46%           0                 0         -
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                    610                84    86.23%         115                 7    93.91%         810                72    91.11%         414                98    76.33%
```